### PR TITLE
Fix libsass dependency on Mac

### DIFF
--- a/compose/local/django/Dockerfile
+++ b/compose/local/django/Dockerfile
@@ -45,6 +45,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   # Translations dependencies
   gettext \
   git \
+  # Add gcc compiler in order to compile libsass on MAC \
+  gcc \
   # Geospatioal dependencies
   binutils libproj-dev gdal-bin \
   # make: for data commands

--- a/compose/local/django/Dockerfile
+++ b/compose/local/django/Dockerfile
@@ -46,7 +46,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   gettext \
   git \
   # Add gcc compiler in order to compile libsass on MAC \
-  gcc \
+  gcc g++ \
   # Geospatioal dependencies
   binutils libproj-dev gdal-bin \
   # make: for data commands


### PR DESCRIPTION
This PR solves error when installing libsass v0.23.0 on mac.