### PR TITLE
Feature/added value results design

### DIFF
--- a/slapp/kommWertTool/templates/added_value_results.html
+++ b/slapp/kommWertTool/templates/added_value_results.html
@@ -202,12 +202,6 @@
                   </div>
                 </div>
               </div>
-            </div>  
-            <div class="row">
-              <div class="col-md-6 d-flex align-items-center">
-                <div id="area_lease_income_loader" class="loader"></div>
-                <div id="area_lease_income_chart" style="width: 100%;  height: 400px;"></div>
-              </div>  
             </div>
             {% else %}
             <div class="alert alert-info mt-4 mb-4" role="alert">

--- a/slapp/kommWertTool/templates/added_value_results.html
+++ b/slapp/kommWertTool/templates/added_value_results.html
@@ -19,7 +19,9 @@
         abzuschätzen und fundierte Entscheidungen für eine nachhaltige Entwicklung zu treffen.
       </p>
     </header>
-    <div class="av-results">
+  </div>
+  <div class="av-results">
+    <div class="av-results__container">
       <div class="av-results__tabs">
         <button class="tab-button active" data-tab="costs">Kosten</button>
         <button class="tab-button" data-tab="taxes">Grundsteuer</button>
@@ -27,66 +29,22 @@
       </div>
       <div class="av-results__tabs-content">
         <div id="costs" class="tab-content active">
-          <div class="container mt-1 addedValue" id="charts">
+          <div class="container addedValue" id="charts">
             {{ results|json_script:"results-data" }}
-            <div class="row mt-5">
-              <div class="col-md-6 d-flex align-items-center">
-                <div id="eeg_participation_loader" class="loader"></div>
-                <div id="eeg_participation_chart" style="width: 100%;  height: 400px;"></div>
-              </div>
-              <div class="col-md-6">
-                <h3 class="smallHeadline">EEG-Beteiligung (jährlich)</h3>
-                <p>
-                  Der 2021 eingeführte § 6 im Erneuerbare-Energien-Gesetz (EEG) ermöglicht Kommunen Einnahmen durch EE-Anlagen zu gewinnen und soll somit zur Akzeptanzsteigerung beitragen. Bis zu 0,2 Cent können pro kWh eingespeister Strommenge durch WEA, FF-PV- und APV-Anlagen in die Haushaltskassen der Gemeinden fließen.
-                </p>
-                <table class="table table-bordered">
-                  <thead>
-                    <tr class="table-info">
-                      <th>WEA</th>
-                      <th>FF-PV</th>
-                      <th>APV</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr>
-                      <td>{{ results.wind_eeg_yearly }} €</td>
-                      <td>{{ results.pv_eeg_yearly }} €</td>
-                      <td>{{ results.apv_eeg_yearly }} €</td>
-                    </tr>
-                  </tbody>
-                </table>
-                <div class="expandable-text bg-light p-4 small text-muted">
-                  <p class="mb-0">
-                    <b>Annahmen:</b>
-                  </p>
-                  <ul class="mb-0">
-                    <li>Es findet keine Eigennutzung der erzeugten Strommmenge statt</li>
-                    <li>Beteiligung von 0,2 Cent pro kWh</li>
-                  </ul>
-                  <span class="collapse">
-                    <p>
-                      Für eine detaillierte Dokumentation aller getroffener Annahmen siehe <a href="#" title="Dokumentation">hier</a>.
-                    </p>
-                  </span>
-                  <a class="expand-btn mt-2 d-block" href="#" role="button">+ Mehr anzeigen</a>
+            <div class="av-results__section">
+              <h2 class="smallHeadline">EEG-Beteiligung (jährlich)</h2>
+              <div class="av-results__wrapper">
+                <div class="av-results__chart">
+                  <div id="eeg_participation_loader" class="loader"></div>
+                  <div id="eeg_participation_chart" style="width: 100%;  height: 400px;"></div>
                 </div>
-              </div>
-            </div>
-            {% if results.choosen_mun != "0" and results.check_county != "check_county_sh" %}
-              <hr />
-              <div class="row">
-                <div class="col-md-6 d-flex align-items-center">
-                  <div id="wind_solar_euro_loader" class="loader"></div>
-                  <div id="wind_solar_euro_chart" style="width: 100%;  height: 400px;"></div>
-                </div>
-                <div class="col-md-6">
-                  <h3 class="smallHeadline">Wind- & Solar-Euro (jährlich)</h3>
+                <div class="av-results__table">
                   <p>
-                    Um die Akzeptanz von WEA und PV-Anlagen zu steigern, hat der Landtag Brandenburg zwei Sonderregelungen verabschiedet. Ab 2025 müssen Betreibende von FF-PV- und APV-Anlagen 2.000,00 Euro pro MW und Jahr an die jeweilige Standortgemeinde zahlen. Ab 2026 zahlen Anlagenbetreibende von WEA 5.000,00 Euro pro installierten MW. Beteiligt werden alle Gemeinden, die sich in einem Radius von drei Kilometern um den Standort der WEA befinden.
+                    Der 2021 eingeführte § 6 im Erneuerbare-Energien-Gesetz (EEG) ermöglicht Kommunen Einnahmen durch EE-Anlagen zu gewinnen und soll somit zur Akzeptanzsteigerung beitragen. Bis zu 0,2 Cent können pro kWh eingespeister Strommenge durch WEA, FF-PV- und APV-Anlagen in die Haushaltskassen der Gemeinden fließen.
                   </p>
                   <table class="table table-bordered">
                     <thead>
-                      <tr class="table-info">
+                      <tr>
                         <th>WEA</th>
                         <th>FF-PV</th>
                         <th>APV</th>
@@ -94,33 +52,77 @@
                     </thead>
                     <tbody>
                       <tr>
-                        <td>{{ results.wind_sr_bb_yearly }} €</td>
-                        <td>{{ results.pv_sr_bb_yearly }} €</td>
-                        <td>{{ results.apv_sr_bb_yearly }} €</td>
+                        <td>{{ results.wind_eeg_yearly }} €</td>
+                        <td>{{ results.pv_eeg_yearly }} €</td>
+                        <td>{{ results.apv_eeg_yearly }} €</td>
                       </tr>
                     </tbody>
                   </table>
-                  <div class="expandable-text bg-light p-4 small text-muted">
-                    <p class="mb-0">
+                  <div class="av-results__details">
+                    <p>
                       <b>Annahmen:</b>
                     </p>
-                    <ul>
-                      <li>
-                        Die bisher geltende Regelung von 10.000,00 pro WEA wird nicht berücksichtigt. Es wird davon ausgegangen, dass alle WEA erst ab 2026 in Betrieb gehen.
-                      </li>
+                    <ul class="mb-0">
+                      <li>Es findet keine Eigennutzung der erzeugten Strommmenge statt</li>
+                      <li>Beteiligung von 0,2 Cent pro kWh</li>
                     </ul>
-                    <span class="collapse">
+                    <span>
                       <p>
                         Für eine detaillierte Dokumentation aller getroffener Annahmen siehe <a href="#" title="Dokumentation">hier</a>.
                       </p>
                     </span>
-                    <a class="expand-btn mt-2 d-block" href="#" role="button">+ Mehr anzeigen</a>
+                  </div>
+                </div>
+              </div>
+            </div>
+            {% if results.choosen_mun != "0" and results.check_county != "check_county_sh" %}
+              <div class="av-results__section">
+                <h2 class="smallHeadline">Wind- & Solar-Euro (jährlich)</h2>
+                <div class="av-results__wrapper">
+                  <div class="av-results__chart">
+                    <div id="wind_solar_euro_loader" class="loader"></div>
+                    <div id="wind_solar_euro_chart" style="width: 100%;  height: 400px;"></div>
+                  </div>
+                  <div class="av-results__table">
+                    <p>
+                      Um die Akzeptanz von WEA und PV-Anlagen zu steigern, hat der Landtag Brandenburg zwei Sonderregelungen verabschiedet. Ab 2025 müssen Betreibende von FF-PV- und APV-Anlagen 2.000,00 Euro pro MW und Jahr an die jeweilige Standortgemeinde zahlen. Ab 2026 zahlen Anlagenbetreibende von WEA 5.000,00 Euro pro installierten MW. Beteiligt werden alle Gemeinden, die sich in einem Radius von drei Kilometern um den Standort der WEA befinden.
+                    </p>
+                    <table class="table table-bordered">
+                      <thead>
+                        <tr>
+                          <th>WEA</th>
+                          <th>FF-PV</th>
+                          <th>APV</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <tr>
+                          <td>{{ results.wind_sr_bb_yearly }} €</td>
+                          <td>{{ results.pv_sr_bb_yearly }} €</td>
+                          <td>{{ results.apv_sr_bb_yearly }} €</td>
+                        </tr>
+                      </tbody>
+                    </table>
+                    <div class="av-results__details">
+                      <p>
+                        <b>Annahmen:</b>
+                      </p>
+                      <ul>
+                        <li>
+                          Die bisher geltende Regelung von 10.000,00 pro WEA wird nicht berücksichtigt. Es wird davon ausgegangen, dass alle WEA erst ab 2026 in Betrieb gehen.
+                        </li>
+                      </ul>
+                      <span>
+                        <p>
+                          Für eine detaillierte Dokumentation aller getroffener Annahmen siehe <a href="#" title="Dokumentation">hier</a>.
+                        </p>
+                      </span>
+                    </div>
                   </div>
                 </div>
               </div>
             {% endif %}
             {% if results.wea_area_income != "0,00" or results.pv_area_income != "0,00" or results.apv_area_income != "0,00" or results.lease_est_income_wea != "0,00" or results.lease_est_income_pv != "0,00" or results.lease_est_income_apv != "0,00" or results.lease_trade_tax_wea != "0,00" or results.lease_trade_tax_pv != "0,00" or results.lease_trade_tax_apv != "0,00" %}
-              <hr />
               <div class="row">
                 <div class="col-md-6 d-flex align-items-center">
                   <div id="area_lease_income_loader" class="loader"></div>
@@ -130,7 +132,7 @@
                   <h3 class="smallHeadline">Einnahmen durch Pachterlöse</h3>
                   <table class="table table-bordered">
                     <thead>
-                      <tr class="table-info">
+                      <tr>
                         <th></th>
                         <th>WEA</th>
                         <th>FF-PV</th>
@@ -158,15 +160,15 @@
                       </tr>
                     </tbody>
                   </table>
-                  <div class="expandable-text bg-light p-4 small text-muted">
-                    <p class="mb-0">
+                  <div class="av-results__details">
+                    <p>
                       <b>Allgemeine Annahmen:</b>
                     </p>
                     <ul>
                       <li>Zugrundeliegende Pachtpreise: WEA = 16.000,00 € pro MW; FF-PV = 3.000,00 € pro ha; APV = 830,00 € pro ha</li>
                     </ul>
                     <span class="collapse">
-                      <p class="mb-0">
+                      <p>
                         <b>Annahmen ESt.-Berechnung:</b>
                       </p>
                       <ul>
@@ -192,131 +194,123 @@
                         Für eine detaillierte Dokumentation aller getroffener Annahmen siehe <a href="#" title="Dokumentation">hier</a>.
                       </p>
                     </span>
-                    <a class="expand-btn mt-2 d-block" href="#" role="button">+ Mehr anzeigen</a>
                   </div>
                 </div>
               </div>
-              <hr />
             {% else %}
               <div class="alert alert-dark mt-4 mb-4" role="alert">
                 <i class="fas fa-info-circle" data-placement="left"></i> Keine Einnahmen durch Pachterlöse vorhanden, da keine Angaben gemacht wurden. Entsprechend wird von Landes-/Bundeseigentum der Potenzialflächen ausgegangen.
               </div>
-              <hr />
             {% endif %}
           </div>
         </div>
         <div id="taxes" class="tab-content">
           {% if results.property_tax_a_wea != "0,00" %}
-          <div class="row">
-            <div class="col-md-12">
-              <h3 class="smallHeadline">Erhöhte Grundsteuer A durch WEA</h3>
+          <div class="av-results__section">
+            <h2 class="smallHeadline">Erhöhte Grundsteuer A durch WEA</h2>
+            <p>
+              Der § 238 Abs. 2 BewG wertet WEA-Standorte auf land- und forstwirtschaftlichen Flächen durch einen Zuschlag auf. Die "abgegrenzte Standortfläche der Windenergieanlage" umfasst Turmgrundfläche, Sicherheitsabstände, Fundamente, Zuwegungen und Kranstellflächen.
+              Der Zuschlag errechnet sich aus dieser Fläche und einem festgelegten Bewertungsfaktor.
+            </p>
+            <p>
+              Anhand der zuvor getätigten Angaben wurde eine Anzahl von <b>{{ results.N_wea }} WEA</b> ermittelt. Die daraus entstehenden Mehreinnahmen durch die Grundsteuer A betragen:
+            </p>
+            <table class="table table-bordered">
+              <thead>
+                <tr>
+                  <th>WEA</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>{{ results.property_tax_a_wea }} €</td>
+                </tr>
+              </tbody>
+            </table>
+            <div class="av-results__details">
               <p>
-                Der § 238 Abs. 2 BewG wertet WEA-Standorte auf land- und forstwirtschaftlichen Flächen durch einen Zuschlag auf. Die "abgegrenzte Standortfläche der Windenergieanlage" umfasst Turmgrundfläche, Sicherheitsabstände, Fundamente, Zuwegungen und Kranstellflächen.
-                Der Zuschlag errechnet sich aus dieser Fläche und einem festgelegten Bewertungsfaktor.
+                <b>Annahmen:</b>
               </p>
-              <p>
-                Anhand der zuvor getätigten Angaben wurde eine Anzahl von <b>{{ results.N_wea }} WEA</b> ermittelt. Die daraus entstehenden Mehreinnahmen durch die Grundsteuer A betragen:
-              </p>
-              <table class="table table-bordered">
-                <thead>
-                  <tr class="table-info">
-                    <th>WEA</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td>{{ results.property_tax_a_wea }} €</td>
-                  </tr>
-                </tbody>
-              </table>
-              <div class="expandable-text bg-light p-4 small text-muted">
-                <p class="mb-0">
-                  <b>Annahmen:</b>
+              <ul>
+                <li>Abgrenzende Standortfläche pro WEA beträgt 0,4 ha</li>
+              </ul>
+              <span>
+                <p>
+                  Für eine detaillierte Dokumentation aller getroffener Annahmen siehe <a href="#" title="Dokumentation">hier</a>.
                 </p>
-                <ul>
-                  <li>Abgrenzende Standortfläche pro WEA beträgt 0,4 ha</li>
-                </ul>
-                <span class="collapse">
-                  <p>
-                    Für eine detaillierte Dokumentation aller getroffener Annahmen siehe <a href="#" title="Dokumentation">hier</a>.
-                  </p>
-                </span>
-                <a class="expand-btn mt-2 d-block" href="#" role="button">+ Mehr anzeigen</a>
-              </div>
+              </span>
             </div>
           </div>
-          <hr />
         {% else %}
           <div class="alert alert-dark mt-4 mb-4" role="alert">
             <i class="fas fa-info-circle" data-placement="left"></i> Grundsteuer A bleibt unverändert, da die WEA auf gemeindeeigenen Flächen errichtet wurden.
           </div>
-          <hr />
         {% endif %}
         </div>
         <div id="revenue" class="tab-content">
-          <h2 class="rowHeader">Gewerbesteuereinnahmen durch Anlagengewinne</h2>
-          <div class="row">
-            {% if results.total_trade_tax_3 != "0,00" %}
-              <div class="col-md-6">
-                <div id="trade_tax_wind_loader" class="loader"></div>
-                <div id="trade_tax_wind_chart" style="width: 100%; height: 400px;"></div>
-              </div>
-            {% endif %}
-            {% if results.total_trade_tax_1 != "0,00" %}
-              <div class="col-md-6">
-                <div id="trade_tax_pv_loader" class="loader"></div>
-                <div id="trade_tax_pv_chart" style="width: 100%; height: 400px;"></div>
-              </div>
-            {% endif %}
-            {% if results.total_trade_tax_2 != "0,00" %}
-              <div class="col-md-6">
-                <div id="trade_tax_apv_loader" class="loader"></div>
-                <div id="trade_tax_apv_chart" style="width: 100%; height: 400px;"></div>
-              </div>
-            {% endif %}
-            <div class="col-md-6 m-auto">
-              <table class="table table-bordered">
-                <thead>
-                  <tr class="table-info">
-                    <th></th>
-                    <th>WEA</th>
-                    <th>FF-PV</th>
-                    <th>APV</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td>Max. jährl. GewSt.</td>
-                    <td>{{ results.max_tax_3 }} €</td>
-                    <td>{{ results.max_tax_1 }} €</td>
-                    <td>{{ results.max_tax_2 }} €</td>
-                  </tr>
-                  <tr>
-                    <td>Einnahmen über 25 Jahre</td>
-                    <td>{{ results.total_trade_tax_3 }} €</td>
-                    <td>{{ results.total_trade_tax_1 }} €</td>
-                    <td>{{ results.total_trade_tax_2 }} €</td>
-                  </tr>
-                </tbody>
-              </table>
-              <div class="expandable-text bg-light p-4 small text-muted">
-                <p class="mb-0">
-                  <b>Allgemeine Annahmen:</b>
-                </p>
-                <ul>
-                  <li>Zinssatz in Höhe von 5 %</li>
-                  <li>Eigenkapitalanteil von 80 %</li>
-                  <li>Tilgungsdauer von 15 Jahren</li>
-                </ul>
-                <span class="collapse">
-                  <p class="mb-0">
+          <div class="av-results__section">
+            <h2 class="rowHeader">Gewerbesteuereinnahmen durch Anlagengewinne</h2>
+            <div class="av-results__section">
+              {% if results.total_trade_tax_3 != "0,00" %}
+                <div class="col-md-6">
+                  <div id="trade_tax_wind_loader" class="loader"></div>
+                  <div id="trade_tax_wind_chart" style="width: 100%; height: 400px;"></div>
+                </div>
+              {% endif %}
+              {% if results.total_trade_tax_1 != "0,00" %}
+                <div class="col-md-6">
+                  <div id="trade_tax_pv_loader" class="loader"></div>
+                  <div id="trade_tax_pv_chart" style="width: 100%; height: 400px;"></div>
+                </div>
+              {% endif %}
+              {% if results.total_trade_tax_2 != "0,00" %}
+                <div class="col-md-6">
+                  <div id="trade_tax_apv_loader" class="loader"></div>
+                  <div id="trade_tax_apv_chart" style="width: 100%; height: 400px;"></div>
+                </div>
+              {% endif %}
+              <div class="col-md-6 m-auto">
+                <table class="table table-bordered">
+                  <thead>
+                    <tr>
+                      <th></th>
+                      <th>WEA</th>
+                      <th>FF-PV</th>
+                      <th>APV</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>Max. jährl. GewSt.</td>
+                      <td>{{ results.max_tax_3 }} €</td>
+                      <td>{{ results.max_tax_1 }} €</td>
+                      <td>{{ results.max_tax_2 }} €</td>
+                    </tr>
+                    <tr>
+                      <td>Einnahmen über 25 Jahre</td>
+                      <td>{{ results.total_trade_tax_3 }} €</td>
+                      <td>{{ results.total_trade_tax_1 }} €</td>
+                      <td>{{ results.total_trade_tax_2 }} €</td>
+                    </tr>
+                  </tbody>
+                </table>
+                <div class="av-results__details">
+                  <p>
+                    <b>Allgemeine Annahmen:</b>
+                  </p>
+                  <ul>
+                    <li>Zinssatz in Höhe von 5 %</li>
+                    <li>Eigenkapitalanteil von 80 %</li>
+                    <li>Tilgungsdauer von 15 Jahren</li>
+                  </ul>
+                  <p>
                     <b>Annahmen WEA:</b>
                   </p>
                   <ul>
                     <li>Angenommene Volllaststunden:</li>
                     <li>Jährliche Leistungsdegradation von 0,6 %</li>
                   </ul>
-                  <p class="mb-0">
+                  <p>
                     <b>Annahmen FF-PV:</b>
                   </p>
                   <ul>
@@ -326,36 +320,34 @@
                   <p>
                     Für eine detaillierte Dokumentation aller getroffener Annahmen siehe <a href="#" title="Dokumentation">hier</a>.
                   </p>
-                </span>
-                <a class="expand-btn mt-2 d-block" href="#" role="button">+ Mehr anzeigen</a>
+                </div>
               </div>
             </div>
-          </div>
-          <hr />
-          <h2 class="rowHeader">Gesamteinnahmen über 25 Jahre</h2>
-          <div class="row">
-            <div class="col-md-12">
-              <div id="total_income_loader" class="loader"></div>
-              <div id="total_income_chart" style="width: 100%; height: 500px;"></div>
+            <h2 class="rowHeader">Gesamteinnahmen über 25 Jahre</h2>
+            <div class="row">
+              <div class="col-md-12">
+                <div id="total_income_loader" class="loader"></div>
+                <div id="total_income_chart" style="width: 100%; height: 500px;"></div>
+              </div>
             </div>
-          </div>
-          <div class="col-md-6 m-auto">
-            <table class="table table-bordered">
-              <thead>
-                <tr class="table-info">
-                  <th>WEA</th>
-                  <th>FF-PV</th>
-                  <th>APV</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td>{{ results.sum_wea }} €</td>
-                  <td>{{ results.sum_ff_pv }} €</td>
-                  <td>{{ results.sum_agri_pv }} €</td>
-                </tr>
-              </tbody>
-            </table>
+            <div class="col-md-6 m-auto">
+              <table class="table table-bordered">
+                <thead>
+                  <tr>
+                    <th>WEA</th>
+                    <th>FF-PV</th>
+                    <th>APV</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>{{ results.sum_wea }} €</td>
+                    <td>{{ results.sum_ff_pv }} €</td>
+                    <td>{{ results.sum_agri_pv }} €</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
           </div>
         </div>
       </div>

--- a/slapp/kommWertTool/templates/added_value_results.html
+++ b/slapp/kommWertTool/templates/added_value_results.html
@@ -263,7 +263,7 @@
           <div class="av-results__section">
             <h2 class="rowHeader">Gewerbesteuereinnahmen durch Anlagengewinne</h2>
             <div class="av-results__wrapper">
-              <div class="av-results__charts">
+              <div class="av-results__chart">
                 {% if results.total_trade_tax_3 != "0,00" %}
                 <div class="d-flex align-items-center">
                   <div id="trade_tax_wind_loader" class="loader"></div>

--- a/slapp/kommWertTool/templates/added_value_results.html
+++ b/slapp/kommWertTool/templates/added_value_results.html
@@ -23,9 +23,9 @@
   <div class="av-results">
     <div class="av-results__container">
       <div class="av-results__tabs">
-        <button class="tab-button active" data-tab="costs">Kosten</button>
+        <button class="tab-button active" data-tab="costs">Einnahmen</button>
         <button class="tab-button" data-tab="taxes">Grundsteuer</button>
-        <button class="tab-button" data-tab="revenue">Einnahmen</button>
+        <button class="tab-button" data-tab="revenue">Gesamteinnahmen</button>
       </div>
       <div class="av-results__tabs-content">
         <div id="costs" class="tab-content active">

--- a/slapp/kommWertTool/templates/added_value_results.html
+++ b/slapp/kommWertTool/templates/added_value_results.html
@@ -19,184 +19,194 @@
         abzuschätzen und fundierte Entscheidungen für eine nachhaltige Entwicklung zu treffen.
       </p>
     </header>
-    <div class="av-content">
-      <div class="container mt-1 addedValue" id="charts">
-        {{ results|json_script:"results-data" }}
-        <div class="row mt-5">
-          <div class="col-md-6 d-flex align-items-center">
-            <div id="eeg_participation_loader" class="loader"></div>
-            <div id="eeg_participation_chart" style="width: 100%;  height: 400px;"></div>
-          </div>
-          <div class="col-md-6">
-            <h3 class="smallHeadline">EEG-Beteiligung (jährlich)</h3>
-            <p>
-              Der 2021 eingeführte § 6 im Erneuerbare-Energien-Gesetz (EEG) ermöglicht Kommunen Einnahmen durch EE-Anlagen zu gewinnen und soll somit zur Akzeptanzsteigerung beitragen. Bis zu 0,2 Cent können pro kWh eingespeister Strommenge durch WEA, FF-PV- und APV-Anlagen in die Haushaltskassen der Gemeinden fließen.
-            </p>
-            <table class="table table-bordered">
-              <thead>
-                <tr class="table-info">
-                  <th>WEA</th>
-                  <th>FF-PV</th>
-                  <th>APV</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td>{{ results.wind_eeg_yearly }} €</td>
-                  <td>{{ results.pv_eeg_yearly }} €</td>
-                  <td>{{ results.apv_eeg_yearly }} €</td>
-                </tr>
-              </tbody>
-            </table>
-            <div class="expandable-text bg-light p-4 small text-muted">
-              <p class="mb-0">
-                <b>Annahmen:</b>
-              </p>
-              <ul class="mb-0">
-                <li>Es findet keine Eigennutzung der erzeugten Strommmenge statt</li>
-                <li>Beteiligung von 0,2 Cent pro kWh</li>
-              </ul>
-              <span class="collapse">
+    <div class="av-results">
+      <div class="av-results__tabs">
+        <button class="tab-button active" data-tab="costs">Kosten</button>
+        <button class="tab-button" data-tab="taxes">Grundsteuer</button>
+        <button class="tab-button" data-tab="revenue">Einnahmen</button>
+      </div>
+      <div class="av-results__tabs-content">
+        <div id="costs" class="tab-content active">
+          <div class="container mt-1 addedValue" id="charts">
+            {{ results|json_script:"results-data" }}
+            <div class="row mt-5">
+              <div class="col-md-6 d-flex align-items-center">
+                <div id="eeg_participation_loader" class="loader"></div>
+                <div id="eeg_participation_chart" style="width: 100%;  height: 400px;"></div>
+              </div>
+              <div class="col-md-6">
+                <h3 class="smallHeadline">EEG-Beteiligung (jährlich)</h3>
                 <p>
-                  Für eine detaillierte Dokumentation aller getroffener Annahmen siehe <a href="#" title="Dokumentation">hier</a>.
+                  Der 2021 eingeführte § 6 im Erneuerbare-Energien-Gesetz (EEG) ermöglicht Kommunen Einnahmen durch EE-Anlagen zu gewinnen und soll somit zur Akzeptanzsteigerung beitragen. Bis zu 0,2 Cent können pro kWh eingespeister Strommenge durch WEA, FF-PV- und APV-Anlagen in die Haushaltskassen der Gemeinden fließen.
                 </p>
-              </span>
-              <a class="expand-btn mt-2 d-block" href="#" role="button">+ Mehr anzeigen</a>
+                <table class="table table-bordered">
+                  <thead>
+                    <tr class="table-info">
+                      <th>WEA</th>
+                      <th>FF-PV</th>
+                      <th>APV</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>{{ results.wind_eeg_yearly }} €</td>
+                      <td>{{ results.pv_eeg_yearly }} €</td>
+                      <td>{{ results.apv_eeg_yearly }} €</td>
+                    </tr>
+                  </tbody>
+                </table>
+                <div class="expandable-text bg-light p-4 small text-muted">
+                  <p class="mb-0">
+                    <b>Annahmen:</b>
+                  </p>
+                  <ul class="mb-0">
+                    <li>Es findet keine Eigennutzung der erzeugten Strommmenge statt</li>
+                    <li>Beteiligung von 0,2 Cent pro kWh</li>
+                  </ul>
+                  <span class="collapse">
+                    <p>
+                      Für eine detaillierte Dokumentation aller getroffener Annahmen siehe <a href="#" title="Dokumentation">hier</a>.
+                    </p>
+                  </span>
+                  <a class="expand-btn mt-2 d-block" href="#" role="button">+ Mehr anzeigen</a>
+                </div>
+              </div>
             </div>
+            {% if results.choosen_mun != "0" and results.check_county != "check_county_sh" %}
+              <hr />
+              <div class="row">
+                <div class="col-md-6 d-flex align-items-center">
+                  <div id="wind_solar_euro_loader" class="loader"></div>
+                  <div id="wind_solar_euro_chart" style="width: 100%;  height: 400px;"></div>
+                </div>
+                <div class="col-md-6">
+                  <h3 class="smallHeadline">Wind- & Solar-Euro (jährlich)</h3>
+                  <p>
+                    Um die Akzeptanz von WEA und PV-Anlagen zu steigern, hat der Landtag Brandenburg zwei Sonderregelungen verabschiedet. Ab 2025 müssen Betreibende von FF-PV- und APV-Anlagen 2.000,00 Euro pro MW und Jahr an die jeweilige Standortgemeinde zahlen. Ab 2026 zahlen Anlagenbetreibende von WEA 5.000,00 Euro pro installierten MW. Beteiligt werden alle Gemeinden, die sich in einem Radius von drei Kilometern um den Standort der WEA befinden.
+                  </p>
+                  <table class="table table-bordered">
+                    <thead>
+                      <tr class="table-info">
+                        <th>WEA</th>
+                        <th>FF-PV</th>
+                        <th>APV</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr>
+                        <td>{{ results.wind_sr_bb_yearly }} €</td>
+                        <td>{{ results.pv_sr_bb_yearly }} €</td>
+                        <td>{{ results.apv_sr_bb_yearly }} €</td>
+                      </tr>
+                    </tbody>
+                  </table>
+                  <div class="expandable-text bg-light p-4 small text-muted">
+                    <p class="mb-0">
+                      <b>Annahmen:</b>
+                    </p>
+                    <ul>
+                      <li>
+                        Die bisher geltende Regelung von 10.000,00 pro WEA wird nicht berücksichtigt. Es wird davon ausgegangen, dass alle WEA erst ab 2026 in Betrieb gehen.
+                      </li>
+                    </ul>
+                    <span class="collapse">
+                      <p>
+                        Für eine detaillierte Dokumentation aller getroffener Annahmen siehe <a href="#" title="Dokumentation">hier</a>.
+                      </p>
+                    </span>
+                    <a class="expand-btn mt-2 d-block" href="#" role="button">+ Mehr anzeigen</a>
+                  </div>
+                </div>
+              </div>
+            {% endif %}
+            {% if results.wea_area_income != "0,00" or results.pv_area_income != "0,00" or results.apv_area_income != "0,00" or results.lease_est_income_wea != "0,00" or results.lease_est_income_pv != "0,00" or results.lease_est_income_apv != "0,00" or results.lease_trade_tax_wea != "0,00" or results.lease_trade_tax_pv != "0,00" or results.lease_trade_tax_apv != "0,00" %}
+              <hr />
+              <div class="row">
+                <div class="col-md-6 d-flex align-items-center">
+                  <div id="area_lease_income_loader" class="loader"></div>
+                  <div id="area_lease_income_chart" style="width: 100%;  height: 400px;"></div>
+                </div>
+                <div class="col-md-6 m-auto">
+                  <h3 class="smallHeadline">Einnahmen durch Pachterlöse</h3>
+                  <table class="table table-bordered">
+                    <thead>
+                      <tr class="table-info">
+                        <th></th>
+                        <th>WEA</th>
+                        <th>FF-PV</th>
+                        <th>APV</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr>
+                        <td>Pachteinnahmen</td>
+                        <td>{{ results.wea_area_income }} €</td>
+                        <td>{{ results.pv_area_income }} €</td>
+                        <td>{{ results.apv_area_income }} €</td>
+                      </tr>
+                      <tr>
+                        <td>Komm. ESt.-Anteil</td>
+                        <td>{{ results.lease_est_income_wea }} €</td>
+                        <td>{{ results.lease_est_income_pv }} €</td>
+                        <td>{{ results.lease_est_income_apv }} €</td>
+                      </tr>
+                      <tr>
+                        <td>Komm. GewSt.-Anteil</td>
+                        <td>{{ results.lease_trade_tax_wea }} €</td>
+                        <td>{{ results.lease_trade_tax_pv }} €</td>
+                        <td>{{ results.lease_trade_tax_apv }} €</td>
+                      </tr>
+                    </tbody>
+                  </table>
+                  <div class="expandable-text bg-light p-4 small text-muted">
+                    <p class="mb-0">
+                      <b>Allgemeine Annahmen:</b>
+                    </p>
+                    <ul>
+                      <li>Zugrundeliegende Pachtpreise: WEA = 16.000,00 € pro MW; FF-PV = 3.000,00 € pro ha; APV = 830,00 € pro ha</li>
+                    </ul>
+                    <span class="collapse">
+                      <p class="mb-0">
+                        <b>Annahmen ESt.-Berechnung:</b>
+                      </p>
+                      <ul>
+                        <li>
+                          Durchschnittliches DE-weites Brutto-Jahreseinkommen von 59.094,00 € <a href="https://www.destatis.de/DE/Themen/Arbeit/Verdienste/Verdienste-Branche-Berufe/Tabellen/bruttojahresverdienst.html"
+            title="Statistisches Bundesamt"
+            target="_blank"><i class="fas fa-link"></i></a>
+                        </li>
+                        <li>ledige Person</li>
+                      </ul>
+                      <p class="mb-0">
+                        <b>Annahmen GewSt.-Berechnung:</b>
+                      </p>
+                      <ul>
+                        <li>Kein Steuerfreibetrag aufgrund von Unternehmensform</li>
+                        <li>
+                          Berücksichtigung der Gewerbesteuerumlage laut Gemeindefinanzreformgesetz <a href="https://www.bundesfinanzministerium.de/Content/DE/Standardartikel/Themen/Oeffentliche_Finanzen/Foederale_Finanzbeziehungen/Kommunalfinanzen/Gemeindefinanzreform/entwicklung-gewerbesteuerumlage.pdf"
+            target="_blank"
+            title="Gewerbesteuerumlage"><i class="fas fa-link"></i></a>
+                        </li>
+                      </ul>
+                      <p>
+                        Für eine detaillierte Dokumentation aller getroffener Annahmen siehe <a href="#" title="Dokumentation">hier</a>.
+                      </p>
+                    </span>
+                    <a class="expand-btn mt-2 d-block" href="#" role="button">+ Mehr anzeigen</a>
+                  </div>
+                </div>
+              </div>
+              <hr />
+            {% else %}
+              <div class="alert alert-dark mt-4 mb-4" role="alert">
+                <i class="fas fa-info-circle" data-placement="left"></i> Keine Einnahmen durch Pachterlöse vorhanden, da keine Angaben gemacht wurden. Entsprechend wird von Landes-/Bundeseigentum der Potenzialflächen ausgegangen.
+              </div>
+              <hr />
+            {% endif %}
           </div>
         </div>
-        {% if results.choosen_mun != "0" and results.check_county != "check_county_sh" %}
-          <hr />
-          <div class="row">
-            <div class="col-md-6 d-flex align-items-center">
-              <div id="wind_solar_euro_loader" class="loader"></div>
-              <div id="wind_solar_euro_chart" style="width: 100%;  height: 400px;"></div>
-            </div>
-            <div class="col-md-6">
-              <h3 class="smallHeadline">Wind- & Solar-Euro (jährlich)</h3>
-              <p>
-                Um die Akzeptanz von WEA und PV-Anlagen zu steigern, hat der Landtag Brandenburg zwei Sonderregelungen verabschiedet. Ab 2025 müssen Betreibende von FF-PV- und APV-Anlagen 2.000,00 Euro pro MW und Jahr an die jeweilige Standortgemeinde zahlen. Ab 2026 zahlen Anlagenbetreibende von WEA 5.000,00 Euro pro installierten MW. Beteiligt werden alle Gemeinden, die sich in einem Radius von drei Kilometern um den Standort der WEA befinden.
-              </p>
-              <table class="table table-bordered">
-                <thead>
-                  <tr class="table-info">
-                    <th>WEA</th>
-                    <th>FF-PV</th>
-                    <th>APV</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td>{{ results.wind_sr_bb_yearly }} €</td>
-                    <td>{{ results.pv_sr_bb_yearly }} €</td>
-                    <td>{{ results.apv_sr_bb_yearly }} €</td>
-                  </tr>
-                </tbody>
-              </table>
-              <div class="expandable-text bg-light p-4 small text-muted">
-                <p class="mb-0">
-                  <b>Annahmen:</b>
-                </p>
-                <ul>
-                  <li>
-                    Die bisher geltende Regelung von 10.000,00 pro WEA wird nicht berücksichtigt. Es wird davon ausgegangen, dass alle WEA erst ab 2026 in Betrieb gehen.
-                  </li>
-                </ul>
-                <span class="collapse">
-                  <p>
-                    Für eine detaillierte Dokumentation aller getroffener Annahmen siehe <a href="#" title="Dokumentation">hier</a>.
-                  </p>
-                </span>
-                <a class="expand-btn mt-2 d-block" href="#" role="button">+ Mehr anzeigen</a>
-              </div>
-            </div>
-          </div>
-        {% endif %}
-        {% if results.wea_area_income != "0,00" or results.pv_area_income != "0,00" or results.apv_area_income != "0,00" or results.lease_est_income_wea != "0,00" or results.lease_est_income_pv != "0,00" or results.lease_est_income_apv != "0,00" or results.lease_trade_tax_wea != "0,00" or results.lease_trade_tax_pv != "0,00" or results.lease_trade_tax_apv != "0,00" %}
-          <hr />
-          <div class="row">
-            <div class="col-md-6 d-flex align-items-center">
-              <div id="area_lease_income_loader" class="loader"></div>
-              <div id="area_lease_income_chart" style="width: 100%;  height: 400px;"></div>
-            </div>
-            <div class="col-md-6 m-auto">
-              <h3 class="smallHeadline">Einnahmen durch Pachterlöse</h3>
-              <table class="table table-bordered">
-                <thead>
-                  <tr class="table-info">
-                    <th></th>
-                    <th>WEA</th>
-                    <th>FF-PV</th>
-                    <th>APV</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td>Pachteinnahmen</td>
-                    <td>{{ results.wea_area_income }} €</td>
-                    <td>{{ results.pv_area_income }} €</td>
-                    <td>{{ results.apv_area_income }} €</td>
-                  </tr>
-                  <tr>
-                    <td>Komm. ESt.-Anteil</td>
-                    <td>{{ results.lease_est_income_wea }} €</td>
-                    <td>{{ results.lease_est_income_pv }} €</td>
-                    <td>{{ results.lease_est_income_apv }} €</td>
-                  </tr>
-                  <tr>
-                    <td>Komm. GewSt.-Anteil</td>
-                    <td>{{ results.lease_trade_tax_wea }} €</td>
-                    <td>{{ results.lease_trade_tax_pv }} €</td>
-                    <td>{{ results.lease_trade_tax_apv }} €</td>
-                  </tr>
-                </tbody>
-              </table>
-              <div class="expandable-text bg-light p-4 small text-muted">
-                <p class="mb-0">
-                  <b>Allgemeine Annahmen:</b>
-                </p>
-                <ul>
-                  <li>Zugrundeliegende Pachtpreise: WEA = 16.000,00 € pro MW; FF-PV = 3.000,00 € pro ha; APV = 830,00 € pro ha</li>
-                </ul>
-                <span class="collapse">
-                  <p class="mb-0">
-                    <b>Annahmen ESt.-Berechnung:</b>
-                  </p>
-                  <ul>
-                    <li>
-                      Durchschnittliches DE-weites Brutto-Jahreseinkommen von 59.094,00 € <a href="https://www.destatis.de/DE/Themen/Arbeit/Verdienste/Verdienste-Branche-Berufe/Tabellen/bruttojahresverdienst.html"
-        title="Statistisches Bundesamt"
-        target="_blank"><i class="fas fa-link"></i></a>
-                    </li>
-                    <li>ledige Person</li>
-                  </ul>
-                  <p class="mb-0">
-                    <b>Annahmen GewSt.-Berechnung:</b>
-                  </p>
-                  <ul>
-                    <li>Kein Steuerfreibetrag aufgrund von Unternehmensform</li>
-                    <li>
-                      Berücksichtigung der Gewerbesteuerumlage laut Gemeindefinanzreformgesetz <a href="https://www.bundesfinanzministerium.de/Content/DE/Standardartikel/Themen/Oeffentliche_Finanzen/Foederale_Finanzbeziehungen/Kommunalfinanzen/Gemeindefinanzreform/entwicklung-gewerbesteuerumlage.pdf"
-        target="_blank"
-        title="Gewerbesteuerumlage"><i class="fas fa-link"></i></a>
-                    </li>
-                  </ul>
-                  <p>
-                    Für eine detaillierte Dokumentation aller getroffener Annahmen siehe <a href="#" title="Dokumentation">hier</a>.
-                  </p>
-                </span>
-                <a class="expand-btn mt-2 d-block" href="#" role="button">+ Mehr anzeigen</a>
-              </div>
-            </div>
-          </div>
-          <hr />
-        {% else %}
-          <div class="alert alert-dark mt-4 mb-4" role="alert">
-            <i class="fas fa-info-circle" data-placement="left"></i> Keine Einnahmen durch Pachterlöse vorhanden, da keine Angaben gemacht wurden. Entsprechend wird von Landes-/Bundeseigentum der Potenzialflächen ausgegangen.
-          </div>
-          <hr />
-        {% endif %}
-        {% if results.property_tax_a_wea != "0,00" %}
+        <div id="taxes" class="tab-content">
+          {% if results.property_tax_a_wea != "0,00" %}
           <div class="row">
             <div class="col-md-12">
               <h3 class="smallHeadline">Erhöhte Grundsteuer A durch WEA</h3>
@@ -242,31 +252,97 @@
           </div>
           <hr />
         {% endif %}
-        <h2 class="rowHeader">Gewerbesteuereinnahmen durch Anlagengewinne</h2>
-        <div class="row">
-          {% if results.total_trade_tax_3 != "0,00" %}
-            <div class="col-md-6">
-              <div id="trade_tax_wind_loader" class="loader"></div>
-              <div id="trade_tax_wind_chart" style="width: 100%; height: 400px;"></div>
+        </div>
+        <div id="revenue" class="tab-content">
+          <h2 class="rowHeader">Gewerbesteuereinnahmen durch Anlagengewinne</h2>
+          <div class="row">
+            {% if results.total_trade_tax_3 != "0,00" %}
+              <div class="col-md-6">
+                <div id="trade_tax_wind_loader" class="loader"></div>
+                <div id="trade_tax_wind_chart" style="width: 100%; height: 400px;"></div>
+              </div>
+            {% endif %}
+            {% if results.total_trade_tax_1 != "0,00" %}
+              <div class="col-md-6">
+                <div id="trade_tax_pv_loader" class="loader"></div>
+                <div id="trade_tax_pv_chart" style="width: 100%; height: 400px;"></div>
+              </div>
+            {% endif %}
+            {% if results.total_trade_tax_2 != "0,00" %}
+              <div class="col-md-6">
+                <div id="trade_tax_apv_loader" class="loader"></div>
+                <div id="trade_tax_apv_chart" style="width: 100%; height: 400px;"></div>
+              </div>
+            {% endif %}
+            <div class="col-md-6 m-auto">
+              <table class="table table-bordered">
+                <thead>
+                  <tr class="table-info">
+                    <th></th>
+                    <th>WEA</th>
+                    <th>FF-PV</th>
+                    <th>APV</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>Max. jährl. GewSt.</td>
+                    <td>{{ results.max_tax_3 }} €</td>
+                    <td>{{ results.max_tax_1 }} €</td>
+                    <td>{{ results.max_tax_2 }} €</td>
+                  </tr>
+                  <tr>
+                    <td>Einnahmen über 25 Jahre</td>
+                    <td>{{ results.total_trade_tax_3 }} €</td>
+                    <td>{{ results.total_trade_tax_1 }} €</td>
+                    <td>{{ results.total_trade_tax_2 }} €</td>
+                  </tr>
+                </tbody>
+              </table>
+              <div class="expandable-text bg-light p-4 small text-muted">
+                <p class="mb-0">
+                  <b>Allgemeine Annahmen:</b>
+                </p>
+                <ul>
+                  <li>Zinssatz in Höhe von 5 %</li>
+                  <li>Eigenkapitalanteil von 80 %</li>
+                  <li>Tilgungsdauer von 15 Jahren</li>
+                </ul>
+                <span class="collapse">
+                  <p class="mb-0">
+                    <b>Annahmen WEA:</b>
+                  </p>
+                  <ul>
+                    <li>Angenommene Volllaststunden:</li>
+                    <li>Jährliche Leistungsdegradation von 0,6 %</li>
+                  </ul>
+                  <p class="mb-0">
+                    <b>Annahmen FF-PV:</b>
+                  </p>
+                  <ul>
+                    <li>Angenommene Volllaststunden:</li>
+                    <li>Jährliche Leistungsdegradation von 0,5 %</li>
+                  </ul>
+                  <p>
+                    Für eine detaillierte Dokumentation aller getroffener Annahmen siehe <a href="#" title="Dokumentation">hier</a>.
+                  </p>
+                </span>
+                <a class="expand-btn mt-2 d-block" href="#" role="button">+ Mehr anzeigen</a>
+              </div>
             </div>
-          {% endif %}
-          {% if results.total_trade_tax_1 != "0,00" %}
-            <div class="col-md-6">
-              <div id="trade_tax_pv_loader" class="loader"></div>
-              <div id="trade_tax_pv_chart" style="width: 100%; height: 400px;"></div>
+          </div>
+          <hr />
+          <h2 class="rowHeader">Gesamteinnahmen über 25 Jahre</h2>
+          <div class="row">
+            <div class="col-md-12">
+              <div id="total_income_loader" class="loader"></div>
+              <div id="total_income_chart" style="width: 100%; height: 500px;"></div>
             </div>
-          {% endif %}
-          {% if results.total_trade_tax_2 != "0,00" %}
-            <div class="col-md-6">
-              <div id="trade_tax_apv_loader" class="loader"></div>
-              <div id="trade_tax_apv_chart" style="width: 100%; height: 400px;"></div>
-            </div>
-          {% endif %}
+          </div>
           <div class="col-md-6 m-auto">
             <table class="table table-bordered">
               <thead>
                 <tr class="table-info">
-                  <th></th>
                   <th>WEA</th>
                   <th>FF-PV</th>
                   <th>APV</th>
@@ -274,76 +350,13 @@
               </thead>
               <tbody>
                 <tr>
-                  <td>Max. jährl. GewSt.</td>
-                  <td>{{ results.max_tax_3 }} €</td>
-                  <td>{{ results.max_tax_1 }} €</td>
-                  <td>{{ results.max_tax_2 }} €</td>
-                </tr>
-                <tr>
-                  <td>Einnahmen über 25 Jahre</td>
-                  <td>{{ results.total_trade_tax_3 }} €</td>
-                  <td>{{ results.total_trade_tax_1 }} €</td>
-                  <td>{{ results.total_trade_tax_2 }} €</td>
+                  <td>{{ results.sum_wea }} €</td>
+                  <td>{{ results.sum_ff_pv }} €</td>
+                  <td>{{ results.sum_agri_pv }} €</td>
                 </tr>
               </tbody>
             </table>
-            <div class="expandable-text bg-light p-4 small text-muted">
-              <p class="mb-0">
-                <b>Allgemeine Annahmen:</b>
-              </p>
-              <ul>
-                <li>Zinssatz in Höhe von 5 %</li>
-                <li>Eigenkapitalanteil von 80 %</li>
-                <li>Tilgungsdauer von 15 Jahren</li>
-              </ul>
-              <span class="collapse">
-                <p class="mb-0">
-                  <b>Annahmen WEA:</b>
-                </p>
-                <ul>
-                  <li>Angenommene Volllaststunden:</li>
-                  <li>Jährliche Leistungsdegradation von 0,6 %</li>
-                </ul>
-                <p class="mb-0">
-                  <b>Annahmen FF-PV:</b>
-                </p>
-                <ul>
-                  <li>Angenommene Volllaststunden:</li>
-                  <li>Jährliche Leistungsdegradation von 0,5 %</li>
-                </ul>
-                <p>
-                  Für eine detaillierte Dokumentation aller getroffener Annahmen siehe <a href="#" title="Dokumentation">hier</a>.
-                </p>
-              </span>
-              <a class="expand-btn mt-2 d-block" href="#" role="button">+ Mehr anzeigen</a>
-            </div>
           </div>
-        </div>
-        <hr />
-        <h2 class="rowHeader">Gesamteinnahmen über 25 Jahre</h2>
-        <div class="row">
-          <div class="col-md-12">
-            <div id="total_income_loader" class="loader"></div>
-            <div id="total_income_chart" style="width: 100%; height: 500px;"></div>
-          </div>
-        </div>
-        <div class="col-md-6 m-auto">
-          <table class="table table-bordered">
-            <thead>
-              <tr class="table-info">
-                <th>WEA</th>
-                <th>FF-PV</th>
-                <th>APV</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>{{ results.sum_wea }} €</td>
-                <td>{{ results.sum_ff_pv }} €</td>
-                <td>{{ results.sum_agri_pv }} €</td>
-              </tr>
-            </tbody>
-          </table>
         </div>
       </div>
     </div>
@@ -489,6 +502,25 @@
         // Diagrammoptionen anwenden
         chart.setOption(option);
       }
+    });
+  </script>
+  <script>
+    document.addEventListener("DOMContentLoaded", function () {
+      const addedValueButtons = document.querySelectorAll(".av-results .tab-button");
+      const addedValueContent = document.querySelectorAll(".av-results .tab-content");
+  
+      addedValueButtons.forEach((button) => {
+        console.log(button);
+        button.addEventListener("click", () => {
+          // Remove active class from all buttons and contents
+          addedValueButtons.forEach((btn) => btn.classList.remove("active"));
+          addedValueContent.forEach((content) => content.classList.remove("active"));
+  
+          // Add active class to clicked button and corresponding content
+          button.classList.add("active");
+          document.getElementById(button.dataset.tab).classList.add("active");
+        });
+      });
     });
   </script>
 {% endblock inline_javascript %}

--- a/slapp/kommWertTool/templates/added_value_results.html
+++ b/slapp/kommWertTool/templates/added_value_results.html
@@ -35,11 +35,13 @@
               <h2 class="smallHeadline">EEG-Beteiligung (jährlich)</h2>
               <div class="av-results__wrapper">
                 <div class="av-results__chart">
-                  <div id="eeg_participation_loader" class="loader"></div>
-                  <div id="eeg_participation_chart" style="width: 100%;  height: 400px;"></div>
+                  <div class="d-flex align-items-center">
+                    <div id="eeg_participation_loader" class="loader"></div>
+                    <div id="eeg_participation_chart" style="width: 100%;  height: 400px;"></div>
+                  </div>
                 </div>
                 <div class="av-results__table">
-                  <p>
+                  <p class="pb-4">
                     Der 2021 eingeführte § 6 im Erneuerbare-Energien-Gesetz (EEG) ermöglicht Kommunen Einnahmen durch EE-Anlagen zu gewinnen und soll somit zur Akzeptanzsteigerung beitragen. Bis zu 0,2 Cent können pro kWh eingespeister Strommenge durch WEA, FF-PV- und APV-Anlagen in die Haushaltskassen der Gemeinden fließen.
                   </p>
                   <table class="table table-bordered">
@@ -80,8 +82,10 @@
                 <h2 class="smallHeadline">Wind- & Solar-Euro (jährlich)</h2>
                 <div class="av-results__wrapper">
                   <div class="av-results__chart">
-                    <div id="wind_solar_euro_loader" class="loader"></div>
-                    <div id="wind_solar_euro_chart" style="width: 100%;  height: 400px;"></div>
+                    <div class="d-flex align-items-center">
+                      <div id="wind_solar_euro_loader" class="loader"></div>
+                      <div id="wind_solar_euro_chart" style="width: 100%;  height: 400px;"></div>
+                    </div>
                   </div>
                   <div class="av-results__table">
                     <p>
@@ -123,13 +127,16 @@
               </div>
             {% endif %}
             {% if results.wea_area_income != "0,00" or results.pv_area_income != "0,00" or results.apv_area_income != "0,00" or results.lease_est_income_wea != "0,00" or results.lease_est_income_pv != "0,00" or results.lease_est_income_apv != "0,00" or results.lease_trade_tax_wea != "0,00" or results.lease_trade_tax_pv != "0,00" or results.lease_trade_tax_apv != "0,00" %}
-              <div class="row">
-                <div class="col-md-6 d-flex align-items-center">
-                  <div id="area_lease_income_loader" class="loader"></div>
-                  <div id="area_lease_income_chart" style="width: 100%;  height: 400px;"></div>
+            <div class="av-results__section">
+              <h2 class="smallHeadline">Einnahmen durch Pachterlöse</h2>
+              <div class="av-results__wrapper">
+                <div class="av-results__chart">
+                  <div class="d-flex align-items-center">
+                    <div id="area_lease_income_loader" class="loader"></div>
+                    <div id="area_lease_income_chart" style="width: 100%;  height: 400px;"></div>
+                  </div>
                 </div>
-                <div class="col-md-6 m-auto">
-                  <h3 class="smallHeadline">Einnahmen durch Pachterlöse</h3>
+                <div class="av-results__table">
                   <table class="table table-bordered">
                     <thead>
                       <tr>
@@ -191,14 +198,21 @@
                       <div class="more">
                         Für eine detaillierte Dokumentation aller getroffener Annahmen siehe <a href="#" title="Dokumentation">hier</a>.
                       </div>
-                    </span>
+                    </div>
                   </div>
                 </div>
               </div>
+            </div>  
+            <div class="row">
+              <div class="col-md-6 d-flex align-items-center">
+                <div id="area_lease_income_loader" class="loader"></div>
+                <div id="area_lease_income_chart" style="width: 100%;  height: 400px;"></div>
+              </div>  
+            </div>
             {% else %}
-              <div class="alert alert-dark mt-4 mb-4" role="alert">
-                <i class="fas fa-info-circle" data-placement="left"></i> Keine Einnahmen durch Pachterlöse vorhanden, da keine Angaben gemacht wurden. Entsprechend wird von Landes-/Bundeseigentum der Potenzialflächen ausgegangen.
-              </div>
+            <div class="alert alert-info mt-4 mb-4" role="alert">
+              <i class="fas fa-info-circle" data-placement="left"></i> Keine Einnahmen durch Pachterlöse vorhanden, da keine Angaben gemacht wurden. Entsprechend wird von Landes-/Bundeseigentum der Potenzialflächen ausgegangen.
+            </div>
             {% endif %}
           </div>
         </div>
@@ -206,36 +220,42 @@
           {% if results.property_tax_a_wea != "0,00" %}
           <div class="av-results__section">
             <h2 class="smallHeadline">Erhöhte Grundsteuer A durch WEA</h2>
-            <p>
-              Der § 238 Abs. 2 BewG wertet WEA-Standorte auf land- und forstwirtschaftlichen Flächen durch einen Zuschlag auf. Die "abgegrenzte Standortfläche der Windenergieanlage" umfasst Turmgrundfläche, Sicherheitsabstände, Fundamente, Zuwegungen und Kranstellflächen.
-              Der Zuschlag errechnet sich aus dieser Fläche und einem festgelegten Bewertungsfaktor.
-            </p>
-            <p>
-              Anhand der zuvor getätigten Angaben wurde eine Anzahl von <b>{{ results.N_wea }} WEA</b> ermittelt. Die daraus entstehenden Mehreinnahmen durch die Grundsteuer A betragen:
-            </p>
-            <table class="table table-bordered">
-              <thead>
-                <tr>
-                  <th>WEA</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td>{{ results.property_tax_a_wea }} €</td>
-                </tr>
-              </tbody>
-            </table>
-            <div class="av-results__details">
-              <div class="title">
-                <h3>Annahmen:</h3>
-              </div>
-              <ul class="list">
-                <li>Abgrenzende Standortfläche pro WEA beträgt 0,4 ha</li>
-              </ul>
-              <div class="more">
+            <div class="av-results__wrapper">
+              <div class="av-results__text">
                 <p>
-                  Für eine detaillierte Dokumentation aller getroffener Annahmen siehe <a href="#" title="Dokumentation">hier</a>.
+                  Der § 238 Abs. 2 BewG wertet WEA-Standorte auf land- und forstwirtschaftlichen Flächen durch einen Zuschlag auf. Die "abgegrenzte Standortfläche der Windenergieanlage" umfasst Turmgrundfläche, Sicherheitsabstände, Fundamente, Zuwegungen und Kranstellflächen.
+                  Der Zuschlag errechnet sich aus dieser Fläche und einem festgelegten Bewertungsfaktor.
                 </p>
+                <p>
+                  Anhand der zuvor getätigten Angaben wurde eine Anzahl von <b>{{ results.N_wea }} WEA</b> ermittelt. Die daraus entstehenden Mehreinnahmen durch die Grundsteuer A betragen:
+                </p>
+              </div>
+              <div class="av-results__table">
+                <table class="table table-bordered">
+                  <thead>
+                    <tr>
+                      <th>WEA</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>{{ results.property_tax_a_wea }} €</td>
+                    </tr>
+                  </tbody>
+                </table>
+                <div class="av-results__details">
+                  <div class="title">
+                    <h3>Annahmen:</h3>
+                  </div>
+                  <ul class="list">
+                    <li>Abgrenzende Standortfläche pro WEA beträgt 0,4 ha</li>
+                  </ul>
+                  <div class="more">
+                    <p>
+                      Für eine detaillierte Dokumentation aller getroffener Annahmen siehe <a href="#" title="Dokumentation">hier</a>.
+                    </p>
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -248,87 +268,97 @@
         <div id="revenue" class="tab-content">
           <div class="av-results__section">
             <h2 class="rowHeader">Gewerbesteuereinnahmen durch Anlagengewinne</h2>
-            {% if results.total_trade_tax_3 != "0,00" %}
-              <div class="col-md-6">
-                <div id="trade_tax_wind_loader" class="loader"></div>
-                <div id="trade_tax_wind_chart" style="width: 100%; height: 400px;"></div>
-              </div>
-            {% endif %}
-            {% if results.total_trade_tax_1 != "0,00" %}
-              <div class="col-md-6">
-                <div id="trade_tax_pv_loader" class="loader"></div>
-                <div id="trade_tax_pv_chart" style="width: 100%; height: 400px;"></div>
-              </div>
-            {% endif %}
-            {% if results.total_trade_tax_2 != "0,00" %}
-              <div class="col-md-6">
-                <div id="trade_tax_apv_loader" class="loader"></div>
-                <div id="trade_tax_apv_chart" style="width: 100%; height: 400px;"></div>
-              </div>
-            {% endif %}
-            <div class="col-md-6 m-auto">
-              <table class="table table-bordered">
-                <thead>
-                  <tr>
-                    <th></th>
-                    <th>WEA</th>
-                    <th>FF-PV</th>
-                    <th>APV</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td>Max. jährl. GewSt.</td>
-                    <td>{{ results.max_tax_3 }} €</td>
-                    <td>{{ results.max_tax_1 }} €</td>
-                    <td>{{ results.max_tax_2 }} €</td>
-                  </tr>
-                  <tr>
-                    <td>Einnahmen über 25 Jahre</td>
-                    <td>{{ results.total_trade_tax_3 }} €</td>
-                    <td>{{ results.total_trade_tax_1 }} €</td>
-                    <td>{{ results.total_trade_tax_2 }} €</td>
-                  </tr>
-                </tbody>
-              </table>
-              <div class="av-results__details">
-                <div class="title">
-                  <h3>Allgemeine Annahmen:</h3>
+            <div class="av-results__wrapper">
+              <div class="av-results__charts">
+                {% if results.total_trade_tax_3 != "0,00" %}
+                <div class="d-flex align-items-center">
+                  <div id="trade_tax_wind_loader" class="loader"></div>
+                  <div id="trade_tax_wind_chart" style="width: 100%; height: 400px;"></div>
                 </div>
-                <ul class="list">
-                  <li>Zinssatz in Höhe von 5 %</li>
-                  <li>Eigenkapitalanteil von 80 %</li>
-                  <li>Tilgungsdauer von 15 Jahren</li>
-                </ul>
-                <div class="title">
-                  <h3>Annahmen WEA:</h3>
+              {% endif %}
+              {% if results.total_trade_tax_1 != "0,00" %}
+                <div class="d-flex align-items-center">
+                  <div id="trade_tax_pv_loader" class="loader"></div>
+                  <div id="trade_tax_pv_chart" style="width: 100%; height: 400px;"></div>
                 </div>
-                <ul class="list">
-                  <li>Angenommene Volllaststunden:</li>
-                  <li>Jährliche Leistungsdegradation von 0,6 %</li>
-                </ul>
-                <div class="title">
-                  <h3>Annahmen FF-PV:</h3>
+              {% endif %}
+              {% if results.total_trade_tax_2 != "0,00" %}
+                <div class="d-flex align-items-center">
+                  <div id="trade_tax_apv_loader" class="loader"></div>
+                  <div id="trade_tax_apv_chart" style="width: 100%; height: 400px;"></div>
                 </div>
-                <ul class="list">
-                  <li>Angenommene Volllaststunden:</li>
-                  <li>Jährliche Leistungsdegradation von 0,5 %</li>
-                </ul>
-                <div class="more">
-                  Für eine detaillierte Dokumentation aller getroffener Annahmen siehe <a href="#" title="Dokumentation">hier</a>.
+              {% endif %}
+              </div>
+              <div class="av-results__table">
+                <table class="table table-bordered">
+                  <thead>
+                    <tr>
+                      <th></th>
+                      <th>WEA</th>
+                      <th>FF-PV</th>
+                      <th>APV</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>Max. jährl. GewSt.</td>
+                      <td>{{ results.max_tax_3 }} €</td>
+                      <td>{{ results.max_tax_1 }} €</td>
+                      <td>{{ results.max_tax_2 }} €</td>
+                    </tr>
+                    <tr>
+                      <td>Einnahmen über 25 Jahre</td>
+                      <td>{{ results.total_trade_tax_3 }} €</td>
+                      <td>{{ results.total_trade_tax_1 }} €</td>
+                      <td>{{ results.total_trade_tax_2 }} €</td>
+                    </tr>
+                  </tbody>
+                </table>
+                <div class="av-results__details">
+                  <div class="title">
+                    <h3>Allgemeine Annahmen:</h3>
+                  </div>
+                  <ul class="list">
+                    <li>Zinssatz in Höhe von 5 %</li>
+                    <li>Eigenkapitalanteil von 80 %</li>
+                    <li>Tilgungsdauer von 15 Jahren</li>
+                  </ul>
+                  <a id="collapseDetailsWinBtn" data-bs-toggle="collapse" href="#collapseDetailsWin" role="button" aria-expanded="false" aria-controls="collapseDetailsWin">
+                  </a>
+                  <div class="collapse" id="collapseDetailsWin" style="margin-top: 1rem;">
+                    <div class="title">
+                      <h3>Annahmen WEA:</h3>
+                    </div>
+                    <ul class="list">
+                      <li>Angenommene Volllaststunden:</li>
+                      <li>Jährliche Leistungsdegradation von 0,6 %</li>
+                    </ul>
+                    <div class="title">
+                      <h3>Annahmen FF-PV:</h3>
+                    </div>
+                    <ul class="list">
+                      <li>Angenommene Volllaststunden:</li>
+                      <li>Jährliche Leistungsdegradation von 0,5 %</li>
+                    </ul>
+                    <div class="more">
+                      Für eine detaillierte Dokumentation aller getroffener Annahmen siehe <a href="#" title="Dokumentation">hier</a>.
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
           <div class="av-results__section">
             <h2 class="rowHeader">Gesamteinnahmen über 25 Jahre</h2>
-            <div class="row">
-              <div class="col-md-12">
-                <div id="total_income_loader" class="loader"></div>
-                <div id="total_income_chart" style="width: 100%; height: 500px;"></div>
+            <div class="av-results__wrapper">
+              <div class="av-results__chart">
+                <div class="d-flex align-items-center">
+                  <div id="total_income_loader" class="loader"></div>
+                  <div id="total_income_chart" style="width: 100%; height: 500px;"></div>
+                </div>
               </div>
             </div>
-            <div class="col-md-6 m-auto">
+            <div class="av-results__table" style="margin-top: 2rem">
               <table class="table table-bordered">
                 <thead>
                   <tr>
@@ -520,5 +550,21 @@
         });
       });
     });
+
+    const collapseDetailsWinBtn = document.getElementById('collapseDetailsWinBtn');
+    const myCollapsible = document.getElementById('collapseDetailsWin');
+
+    const toggleText = document.createElement('span');
+    toggleText.textContent = 'Mehr anzeigen';
+    collapseDetailsWinBtn.appendChild(toggleText);
+
+    myCollapsible.addEventListener('shown.bs.collapse', () => {
+      toggleText.textContent = 'Weniger anzeigen';
+    });
+
+    myCollapsible.addEventListener('hidden.bs.collapse', () => {
+      toggleText.textContent = 'Mehr anzeigen';
+    });
+
   </script>
 {% endblock inline_javascript %}

--- a/slapp/kommWertTool/templates/added_value_results.html
+++ b/slapp/kommWertTool/templates/added_value_results.html
@@ -4,122 +4,333 @@
 {% load static %}
 
 {% block content_no_sidebar %}
-  <h4 class="text-center">Ergebnisse Ihrer Wertschöpfung</h4>
-  <p class="text-center">
-    Dies ist ein Tool zur Berechnung der direkten kommunalen Wertschöpfung durch Windenergie-, Freiflächen-Photovoltaik und Agri-Photovoltaik-Anlagen.
-    Es liefert eine Einschätzung des Wertschöpfungspotenzials basierend auf den eingegebenen Daten.
-    Der Rechner ermittelt die möglichen Einnahmen durch die EEG-Beteiligung,
-    durch Pachteinnahmen sowie durch den Wind- und Solar-Euro in brandenburgischen Gemeinden.
-    Es ist wichtig zu beachten, dass die tatsächliche Wertschöpfung deutlich höher ausfallen kann, wenn lokale Unternehmen einbezogen werden,
-    Bürger-Beteiligungen erfolgen und induzierte Effekte berücksichtigt werden.
-    Dieses Tool bietet Kommunen die Möglichkeit, die direkten wirtschaftlichen Vorteile des Ausbaus erneuerbarer Energien
-    abzuschätzen und fundierte Entscheidungen für eine nachhaltige Entwicklung zu treffen.
-  </p>
-  <div class="container mt-1 addedValue" id="charts">
-    {{ results|json_script:"results-data" }}
-    <div class="row mt-5">
-      <div class="col-md-6 d-flex align-items-center">
-        <div id="eeg_participation_loader" class="loader"></div>
-        <div id="eeg_participation_chart" style="width: 100%;  height: 400px;"></div>
-      </div>
-      <div class="col-md-6">
-        <h3 class="smallHeadline">EEG-Beteiligung (jährlich)</h3>
-        <p>
-          Der 2021 eingeführte § 6 im Erneuerbare-Energien-Gesetz (EEG) ermöglicht Kommunen Einnahmen durch EE-Anlagen zu gewinnen und soll somit zur Akzeptanzsteigerung beitragen. Bis zu 0,2 Cent können pro kWh eingespeister Strommenge durch WEA, FF-PV- und APV-Anlagen in die Haushaltskassen der Gemeinden fließen.
-        </p>
-        <table class="table table-bordered">
-          <thead>
-            <tr class="table-info">
-              <th>WEA</th>
-              <th>FF-PV</th>
-              <th>APV</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>{{ results.wind_eeg_yearly }} €</td>
-              <td>{{ results.pv_eeg_yearly }} €</td>
-              <td>{{ results.apv_eeg_yearly }} €</td>
-            </tr>
-          </tbody>
-        </table>
-        <div class="expandable-text bg-light p-4 small text-muted">
-          <p class="mb-0">
-            <b>Annahmen:</b>
-          </p>
-          <ul class="mb-0">
-            <li>Es findet keine Eigennutzung der erzeugten Strommmenge statt</li>
-            <li>Beteiligung von 0,2 Cent pro kWh</li>
-          </ul>
-          <span class="collapse">
+<div class="av">
+  <div class="av__container">
+    <header>
+      <h1 class="av-sidebar__heading">Ergebnisse Ihrer Wertschöpfung</h1>
+      <p class="av-sidebar__content">
+        Dies ist ein Tool zur Berechnung der direkten kommunalen Wertschöpfung durch Windenergie-, Freiflächen-Photovoltaik und Agri-Photovoltaik-Anlagen.
+        Es liefert eine Einschätzung des Wertschöpfungspotenzials basierend auf den eingegebenen Daten.
+        Der Rechner ermittelt die möglichen Einnahmen durch die EEG-Beteiligung,
+        durch Pachteinnahmen sowie durch den Wind- und Solar-Euro in brandenburgischen Gemeinden.
+        Es ist wichtig zu beachten, dass die tatsächliche Wertschöpfung deutlich höher ausfallen kann, wenn lokale Unternehmen einbezogen werden,
+        Bürger-Beteiligungen erfolgen und induzierte Effekte berücksichtigt werden.
+        Dieses Tool bietet Kommunen die Möglichkeit, die direkten wirtschaftlichen Vorteile des Ausbaus erneuerbarer Energien
+        abzuschätzen und fundierte Entscheidungen für eine nachhaltige Entwicklung zu treffen.
+      </p>
+    </header>
+    <div class="av-content">
+      <div class="container mt-1 addedValue" id="charts">
+        {{ results|json_script:"results-data" }}
+        <div class="row mt-5">
+          <div class="col-md-6 d-flex align-items-center">
+            <div id="eeg_participation_loader" class="loader"></div>
+            <div id="eeg_participation_chart" style="width: 100%;  height: 400px;"></div>
+          </div>
+          <div class="col-md-6">
+            <h3 class="smallHeadline">EEG-Beteiligung (jährlich)</h3>
             <p>
-              Für eine detaillierte Dokumentation aller getroffener Annahmen siehe <a href="#" title="Dokumentation">hier</a>.
+              Der 2021 eingeführte § 6 im Erneuerbare-Energien-Gesetz (EEG) ermöglicht Kommunen Einnahmen durch EE-Anlagen zu gewinnen und soll somit zur Akzeptanzsteigerung beitragen. Bis zu 0,2 Cent können pro kWh eingespeister Strommenge durch WEA, FF-PV- und APV-Anlagen in die Haushaltskassen der Gemeinden fließen.
             </p>
-          </span>
-          <a class="expand-btn mt-2 d-block" href="#" role="button">+ Mehr anzeigen</a>
-        </div>
-      </div>
-    </div>
-    {% if results.choosen_mun != "0" and results.check_county != "check_county_sh" %}
-      <hr />
-      <div class="row">
-        <div class="col-md-6 d-flex align-items-center">
-          <div id="wind_solar_euro_loader" class="loader"></div>
-          <div id="wind_solar_euro_chart" style="width: 100%;  height: 400px;"></div>
-        </div>
-        <div class="col-md-6">
-          <h3 class="smallHeadline">Wind- & Solar-Euro (jährlich)</h3>
-          <p>
-            Um die Akzeptanz von WEA und PV-Anlagen zu steigern, hat der Landtag Brandenburg zwei Sonderregelungen verabschiedet. Ab 2025 müssen Betreibende von FF-PV- und APV-Anlagen 2.000,00 Euro pro MW und Jahr an die jeweilige Standortgemeinde zahlen. Ab 2026 zahlen Anlagenbetreibende von WEA 5.000,00 Euro pro installierten MW. Beteiligt werden alle Gemeinden, die sich in einem Radius von drei Kilometern um den Standort der WEA befinden.
-          </p>
-          <table class="table table-bordered">
-            <thead>
-              <tr class="table-info">
-                <th>WEA</th>
-                <th>FF-PV</th>
-                <th>APV</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>{{ results.wind_sr_bb_yearly }} €</td>
-                <td>{{ results.pv_sr_bb_yearly }} €</td>
-                <td>{{ results.apv_sr_bb_yearly }} €</td>
-              </tr>
-            </tbody>
-          </table>
-          <div class="expandable-text bg-light p-4 small text-muted">
-            <p class="mb-0">
-              <b>Annahmen:</b>
-            </p>
-            <ul>
-              <li>
-                Die bisher geltende Regelung von 10.000,00 pro WEA wird nicht berücksichtigt. Es wird davon ausgegangen, dass alle WEA erst ab 2026 in Betrieb gehen.
-              </li>
-            </ul>
-            <span class="collapse">
-              <p>
-                Für eine detaillierte Dokumentation aller getroffener Annahmen siehe <a href="#" title="Dokumentation">hier</a>.
+            <table class="table table-bordered">
+              <thead>
+                <tr class="table-info">
+                  <th>WEA</th>
+                  <th>FF-PV</th>
+                  <th>APV</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>{{ results.wind_eeg_yearly }} €</td>
+                  <td>{{ results.pv_eeg_yearly }} €</td>
+                  <td>{{ results.apv_eeg_yearly }} €</td>
+                </tr>
+              </tbody>
+            </table>
+            <div class="expandable-text bg-light p-4 small text-muted">
+              <p class="mb-0">
+                <b>Annahmen:</b>
               </p>
-            </span>
-            <a class="expand-btn mt-2 d-block" href="#" role="button">+ Mehr anzeigen</a>
+              <ul class="mb-0">
+                <li>Es findet keine Eigennutzung der erzeugten Strommmenge statt</li>
+                <li>Beteiligung von 0,2 Cent pro kWh</li>
+              </ul>
+              <span class="collapse">
+                <p>
+                  Für eine detaillierte Dokumentation aller getroffener Annahmen siehe <a href="#" title="Dokumentation">hier</a>.
+                </p>
+              </span>
+              <a class="expand-btn mt-2 d-block" href="#" role="button">+ Mehr anzeigen</a>
+            </div>
           </div>
         </div>
-      </div>
-    {% endif %}
-    {% if results.wea_area_income != "0,00" or results.pv_area_income != "0,00" or results.apv_area_income != "0,00" or results.lease_est_income_wea != "0,00" or results.lease_est_income_pv != "0,00" or results.lease_est_income_apv != "0,00" or results.lease_trade_tax_wea != "0,00" or results.lease_trade_tax_pv != "0,00" or results.lease_trade_tax_apv != "0,00" %}
-      <hr />
-      <div class="row">
-        <div class="col-md-6 d-flex align-items-center">
-          <div id="area_lease_income_loader" class="loader"></div>
-          <div id="area_lease_income_chart" style="width: 100%;  height: 400px;"></div>
+        {% if results.choosen_mun != "0" and results.check_county != "check_county_sh" %}
+          <hr />
+          <div class="row">
+            <div class="col-md-6 d-flex align-items-center">
+              <div id="wind_solar_euro_loader" class="loader"></div>
+              <div id="wind_solar_euro_chart" style="width: 100%;  height: 400px;"></div>
+            </div>
+            <div class="col-md-6">
+              <h3 class="smallHeadline">Wind- & Solar-Euro (jährlich)</h3>
+              <p>
+                Um die Akzeptanz von WEA und PV-Anlagen zu steigern, hat der Landtag Brandenburg zwei Sonderregelungen verabschiedet. Ab 2025 müssen Betreibende von FF-PV- und APV-Anlagen 2.000,00 Euro pro MW und Jahr an die jeweilige Standortgemeinde zahlen. Ab 2026 zahlen Anlagenbetreibende von WEA 5.000,00 Euro pro installierten MW. Beteiligt werden alle Gemeinden, die sich in einem Radius von drei Kilometern um den Standort der WEA befinden.
+              </p>
+              <table class="table table-bordered">
+                <thead>
+                  <tr class="table-info">
+                    <th>WEA</th>
+                    <th>FF-PV</th>
+                    <th>APV</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>{{ results.wind_sr_bb_yearly }} €</td>
+                    <td>{{ results.pv_sr_bb_yearly }} €</td>
+                    <td>{{ results.apv_sr_bb_yearly }} €</td>
+                  </tr>
+                </tbody>
+              </table>
+              <div class="expandable-text bg-light p-4 small text-muted">
+                <p class="mb-0">
+                  <b>Annahmen:</b>
+                </p>
+                <ul>
+                  <li>
+                    Die bisher geltende Regelung von 10.000,00 pro WEA wird nicht berücksichtigt. Es wird davon ausgegangen, dass alle WEA erst ab 2026 in Betrieb gehen.
+                  </li>
+                </ul>
+                <span class="collapse">
+                  <p>
+                    Für eine detaillierte Dokumentation aller getroffener Annahmen siehe <a href="#" title="Dokumentation">hier</a>.
+                  </p>
+                </span>
+                <a class="expand-btn mt-2 d-block" href="#" role="button">+ Mehr anzeigen</a>
+              </div>
+            </div>
+          </div>
+        {% endif %}
+        {% if results.wea_area_income != "0,00" or results.pv_area_income != "0,00" or results.apv_area_income != "0,00" or results.lease_est_income_wea != "0,00" or results.lease_est_income_pv != "0,00" or results.lease_est_income_apv != "0,00" or results.lease_trade_tax_wea != "0,00" or results.lease_trade_tax_pv != "0,00" or results.lease_trade_tax_apv != "0,00" %}
+          <hr />
+          <div class="row">
+            <div class="col-md-6 d-flex align-items-center">
+              <div id="area_lease_income_loader" class="loader"></div>
+              <div id="area_lease_income_chart" style="width: 100%;  height: 400px;"></div>
+            </div>
+            <div class="col-md-6 m-auto">
+              <h3 class="smallHeadline">Einnahmen durch Pachterlöse</h3>
+              <table class="table table-bordered">
+                <thead>
+                  <tr class="table-info">
+                    <th></th>
+                    <th>WEA</th>
+                    <th>FF-PV</th>
+                    <th>APV</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>Pachteinnahmen</td>
+                    <td>{{ results.wea_area_income }} €</td>
+                    <td>{{ results.pv_area_income }} €</td>
+                    <td>{{ results.apv_area_income }} €</td>
+                  </tr>
+                  <tr>
+                    <td>Komm. ESt.-Anteil</td>
+                    <td>{{ results.lease_est_income_wea }} €</td>
+                    <td>{{ results.lease_est_income_pv }} €</td>
+                    <td>{{ results.lease_est_income_apv }} €</td>
+                  </tr>
+                  <tr>
+                    <td>Komm. GewSt.-Anteil</td>
+                    <td>{{ results.lease_trade_tax_wea }} €</td>
+                    <td>{{ results.lease_trade_tax_pv }} €</td>
+                    <td>{{ results.lease_trade_tax_apv }} €</td>
+                  </tr>
+                </tbody>
+              </table>
+              <div class="expandable-text bg-light p-4 small text-muted">
+                <p class="mb-0">
+                  <b>Allgemeine Annahmen:</b>
+                </p>
+                <ul>
+                  <li>Zugrundeliegende Pachtpreise: WEA = 16.000,00 € pro MW; FF-PV = 3.000,00 € pro ha; APV = 830,00 € pro ha</li>
+                </ul>
+                <span class="collapse">
+                  <p class="mb-0">
+                    <b>Annahmen ESt.-Berechnung:</b>
+                  </p>
+                  <ul>
+                    <li>
+                      Durchschnittliches DE-weites Brutto-Jahreseinkommen von 59.094,00 € <a href="https://www.destatis.de/DE/Themen/Arbeit/Verdienste/Verdienste-Branche-Berufe/Tabellen/bruttojahresverdienst.html"
+        title="Statistisches Bundesamt"
+        target="_blank"><i class="fas fa-link"></i></a>
+                    </li>
+                    <li>ledige Person</li>
+                  </ul>
+                  <p class="mb-0">
+                    <b>Annahmen GewSt.-Berechnung:</b>
+                  </p>
+                  <ul>
+                    <li>Kein Steuerfreibetrag aufgrund von Unternehmensform</li>
+                    <li>
+                      Berücksichtigung der Gewerbesteuerumlage laut Gemeindefinanzreformgesetz <a href="https://www.bundesfinanzministerium.de/Content/DE/Standardartikel/Themen/Oeffentliche_Finanzen/Foederale_Finanzbeziehungen/Kommunalfinanzen/Gemeindefinanzreform/entwicklung-gewerbesteuerumlage.pdf"
+        target="_blank"
+        title="Gewerbesteuerumlage"><i class="fas fa-link"></i></a>
+                    </li>
+                  </ul>
+                  <p>
+                    Für eine detaillierte Dokumentation aller getroffener Annahmen siehe <a href="#" title="Dokumentation">hier</a>.
+                  </p>
+                </span>
+                <a class="expand-btn mt-2 d-block" href="#" role="button">+ Mehr anzeigen</a>
+              </div>
+            </div>
+          </div>
+          <hr />
+        {% else %}
+          <div class="alert alert-dark mt-4 mb-4" role="alert">
+            <i class="fas fa-info-circle" data-placement="left"></i> Keine Einnahmen durch Pachterlöse vorhanden, da keine Angaben gemacht wurden. Entsprechend wird von Landes-/Bundeseigentum der Potenzialflächen ausgegangen.
+          </div>
+          <hr />
+        {% endif %}
+        {% if results.property_tax_a_wea != "0,00" %}
+          <div class="row">
+            <div class="col-md-12">
+              <h3 class="smallHeadline">Erhöhte Grundsteuer A durch WEA</h3>
+              <p>
+                Der § 238 Abs. 2 BewG wertet WEA-Standorte auf land- und forstwirtschaftlichen Flächen durch einen Zuschlag auf. Die "abgegrenzte Standortfläche der Windenergieanlage" umfasst Turmgrundfläche, Sicherheitsabstände, Fundamente, Zuwegungen und Kranstellflächen.
+                Der Zuschlag errechnet sich aus dieser Fläche und einem festgelegten Bewertungsfaktor.
+              </p>
+              <p>
+                Anhand der zuvor getätigten Angaben wurde eine Anzahl von <b>{{ results.N_wea }} WEA</b> ermittelt. Die daraus entstehenden Mehreinnahmen durch die Grundsteuer A betragen:
+              </p>
+              <table class="table table-bordered">
+                <thead>
+                  <tr class="table-info">
+                    <th>WEA</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>{{ results.property_tax_a_wea }} €</td>
+                  </tr>
+                </tbody>
+              </table>
+              <div class="expandable-text bg-light p-4 small text-muted">
+                <p class="mb-0">
+                  <b>Annahmen:</b>
+                </p>
+                <ul>
+                  <li>Abgrenzende Standortfläche pro WEA beträgt 0,4 ha</li>
+                </ul>
+                <span class="collapse">
+                  <p>
+                    Für eine detaillierte Dokumentation aller getroffener Annahmen siehe <a href="#" title="Dokumentation">hier</a>.
+                  </p>
+                </span>
+                <a class="expand-btn mt-2 d-block" href="#" role="button">+ Mehr anzeigen</a>
+              </div>
+            </div>
+          </div>
+          <hr />
+        {% else %}
+          <div class="alert alert-dark mt-4 mb-4" role="alert">
+            <i class="fas fa-info-circle" data-placement="left"></i> Grundsteuer A bleibt unverändert, da die WEA auf gemeindeeigenen Flächen errichtet wurden.
+          </div>
+          <hr />
+        {% endif %}
+        <h2 class="rowHeader">Gewerbesteuereinnahmen durch Anlagengewinne</h2>
+        <div class="row">
+          {% if results.total_trade_tax_3 != "0,00" %}
+            <div class="col-md-6">
+              <div id="trade_tax_wind_loader" class="loader"></div>
+              <div id="trade_tax_wind_chart" style="width: 100%; height: 400px;"></div>
+            </div>
+          {% endif %}
+          {% if results.total_trade_tax_1 != "0,00" %}
+            <div class="col-md-6">
+              <div id="trade_tax_pv_loader" class="loader"></div>
+              <div id="trade_tax_pv_chart" style="width: 100%; height: 400px;"></div>
+            </div>
+          {% endif %}
+          {% if results.total_trade_tax_2 != "0,00" %}
+            <div class="col-md-6">
+              <div id="trade_tax_apv_loader" class="loader"></div>
+              <div id="trade_tax_apv_chart" style="width: 100%; height: 400px;"></div>
+            </div>
+          {% endif %}
+          <div class="col-md-6 m-auto">
+            <table class="table table-bordered">
+              <thead>
+                <tr class="table-info">
+                  <th></th>
+                  <th>WEA</th>
+                  <th>FF-PV</th>
+                  <th>APV</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Max. jährl. GewSt.</td>
+                  <td>{{ results.max_tax_3 }} €</td>
+                  <td>{{ results.max_tax_1 }} €</td>
+                  <td>{{ results.max_tax_2 }} €</td>
+                </tr>
+                <tr>
+                  <td>Einnahmen über 25 Jahre</td>
+                  <td>{{ results.total_trade_tax_3 }} €</td>
+                  <td>{{ results.total_trade_tax_1 }} €</td>
+                  <td>{{ results.total_trade_tax_2 }} €</td>
+                </tr>
+              </tbody>
+            </table>
+            <div class="expandable-text bg-light p-4 small text-muted">
+              <p class="mb-0">
+                <b>Allgemeine Annahmen:</b>
+              </p>
+              <ul>
+                <li>Zinssatz in Höhe von 5 %</li>
+                <li>Eigenkapitalanteil von 80 %</li>
+                <li>Tilgungsdauer von 15 Jahren</li>
+              </ul>
+              <span class="collapse">
+                <p class="mb-0">
+                  <b>Annahmen WEA:</b>
+                </p>
+                <ul>
+                  <li>Angenommene Volllaststunden:</li>
+                  <li>Jährliche Leistungsdegradation von 0,6 %</li>
+                </ul>
+                <p class="mb-0">
+                  <b>Annahmen FF-PV:</b>
+                </p>
+                <ul>
+                  <li>Angenommene Volllaststunden:</li>
+                  <li>Jährliche Leistungsdegradation von 0,5 %</li>
+                </ul>
+                <p>
+                  Für eine detaillierte Dokumentation aller getroffener Annahmen siehe <a href="#" title="Dokumentation">hier</a>.
+                </p>
+              </span>
+              <a class="expand-btn mt-2 d-block" href="#" role="button">+ Mehr anzeigen</a>
+            </div>
+          </div>
+        </div>
+        <hr />
+        <h2 class="rowHeader">Gesamteinnahmen über 25 Jahre</h2>
+        <div class="row">
+          <div class="col-md-12">
+            <div id="total_income_loader" class="loader"></div>
+            <div id="total_income_chart" style="width: 100%; height: 500px;"></div>
+          </div>
         </div>
         <div class="col-md-6 m-auto">
-          <h3 class="smallHeadline">Einnahmen durch Pachterlöse</h3>
           <table class="table table-bordered">
             <thead>
               <tr class="table-info">
-                <th></th>
                 <th>WEA</th>
                 <th>FF-PV</th>
                 <th>APV</th>
@@ -127,223 +338,18 @@
             </thead>
             <tbody>
               <tr>
-                <td>Pachteinnahmen</td>
-                <td>{{ results.wea_area_income }} €</td>
-                <td>{{ results.pv_area_income }} €</td>
-                <td>{{ results.apv_area_income }} €</td>
-              </tr>
-              <tr>
-                <td>Komm. ESt.-Anteil</td>
-                <td>{{ results.lease_est_income_wea }} €</td>
-                <td>{{ results.lease_est_income_pv }} €</td>
-                <td>{{ results.lease_est_income_apv }} €</td>
-              </tr>
-              <tr>
-                <td>Komm. GewSt.-Anteil</td>
-                <td>{{ results.lease_trade_tax_wea }} €</td>
-                <td>{{ results.lease_trade_tax_pv }} €</td>
-                <td>{{ results.lease_trade_tax_apv }} €</td>
+                <td>{{ results.sum_wea }} €</td>
+                <td>{{ results.sum_ff_pv }} €</td>
+                <td>{{ results.sum_agri_pv }} €</td>
               </tr>
             </tbody>
           </table>
-          <div class="expandable-text bg-light p-4 small text-muted">
-            <p class="mb-0">
-              <b>Allgemeine Annahmen:</b>
-            </p>
-            <ul>
-              <li>Zugrundeliegende Pachtpreise: WEA = 16.000,00 € pro MW; FF-PV = 3.000,00 € pro ha; APV = 830,00 € pro ha</li>
-            </ul>
-            <span class="collapse">
-              <p class="mb-0">
-                <b>Annahmen ESt.-Berechnung:</b>
-              </p>
-              <ul>
-                <li>
-                  Durchschnittliches DE-weites Brutto-Jahreseinkommen von 59.094,00 € <a href="https://www.destatis.de/DE/Themen/Arbeit/Verdienste/Verdienste-Branche-Berufe/Tabellen/bruttojahresverdienst.html"
-    title="Statistisches Bundesamt"
-    target="_blank"><i class="fas fa-link"></i></a>
-                </li>
-                <li>ledige Person</li>
-              </ul>
-              <p class="mb-0">
-                <b>Annahmen GewSt.-Berechnung:</b>
-              </p>
-              <ul>
-                <li>Kein Steuerfreibetrag aufgrund von Unternehmensform</li>
-                <li>
-                  Berücksichtigung der Gewerbesteuerumlage laut Gemeindefinanzreformgesetz <a href="https://www.bundesfinanzministerium.de/Content/DE/Standardartikel/Themen/Oeffentliche_Finanzen/Foederale_Finanzbeziehungen/Kommunalfinanzen/Gemeindefinanzreform/entwicklung-gewerbesteuerumlage.pdf"
-    target="_blank"
-    title="Gewerbesteuerumlage"><i class="fas fa-link"></i></a>
-                </li>
-              </ul>
-              <p>
-                Für eine detaillierte Dokumentation aller getroffener Annahmen siehe <a href="#" title="Dokumentation">hier</a>.
-              </p>
-            </span>
-            <a class="expand-btn mt-2 d-block" href="#" role="button">+ Mehr anzeigen</a>
-          </div>
         </div>
       </div>
-      <hr />
-    {% else %}
-      <div class="alert alert-dark mt-4 mb-4" role="alert">
-        <i class="fas fa-info-circle" data-placement="left"></i> Keine Einnahmen durch Pachterlöse vorhanden, da keine Angaben gemacht wurden. Entsprechend wird von Landes-/Bundeseigentum der Potenzialflächen ausgegangen.
-      </div>
-      <hr />
-    {% endif %}
-    {% if results.property_tax_a_wea != "0,00" %}
-      <div class="row">
-        <div class="col-md-12">
-          <h3 class="smallHeadline">Erhöhte Grundsteuer A durch WEA</h3>
-          <p>
-            Der § 238 Abs. 2 BewG wertet WEA-Standorte auf land- und forstwirtschaftlichen Flächen durch einen Zuschlag auf. Die "abgegrenzte Standortfläche der Windenergieanlage" umfasst Turmgrundfläche, Sicherheitsabstände, Fundamente, Zuwegungen und Kranstellflächen.
-            Der Zuschlag errechnet sich aus dieser Fläche und einem festgelegten Bewertungsfaktor.
-          </p>
-          <p>
-            Anhand der zuvor getätigten Angaben wurde eine Anzahl von <b>{{ results.N_wea }} WEA</b> ermittelt. Die daraus entstehenden Mehreinnahmen durch die Grundsteuer A betragen:
-          </p>
-          <table class="table table-bordered">
-            <thead>
-              <tr class="table-info">
-                <th>WEA</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>{{ results.property_tax_a_wea }} €</td>
-              </tr>
-            </tbody>
-          </table>
-          <div class="expandable-text bg-light p-4 small text-muted">
-            <p class="mb-0">
-              <b>Annahmen:</b>
-            </p>
-            <ul>
-              <li>Abgrenzende Standortfläche pro WEA beträgt 0,4 ha</li>
-            </ul>
-            <span class="collapse">
-              <p>
-                Für eine detaillierte Dokumentation aller getroffener Annahmen siehe <a href="#" title="Dokumentation">hier</a>.
-              </p>
-            </span>
-            <a class="expand-btn mt-2 d-block" href="#" role="button">+ Mehr anzeigen</a>
-          </div>
-        </div>
-      </div>
-      <hr />
-    {% else %}
-      <div class="alert alert-dark mt-4 mb-4" role="alert">
-        <i class="fas fa-info-circle" data-placement="left"></i> Grundsteuer A bleibt unverändert, da die WEA auf gemeindeeigenen Flächen errichtet wurden.
-      </div>
-      <hr />
-    {% endif %}
-    <h2 class="rowHeader">Gewerbesteuereinnahmen durch Anlagengewinne</h2>
-    <div class="row">
-      {% if results.total_trade_tax_3 != "0,00" %}
-        <div class="col-md-6">
-          <div id="trade_tax_wind_loader" class="loader"></div>
-          <div id="trade_tax_wind_chart" style="width: 100%; height: 400px;"></div>
-        </div>
-      {% endif %}
-      {% if results.total_trade_tax_1 != "0,00" %}
-        <div class="col-md-6">
-          <div id="trade_tax_pv_loader" class="loader"></div>
-          <div id="trade_tax_pv_chart" style="width: 100%; height: 400px;"></div>
-        </div>
-      {% endif %}
-      {% if results.total_trade_tax_2 != "0,00" %}
-        <div class="col-md-6">
-          <div id="trade_tax_apv_loader" class="loader"></div>
-          <div id="trade_tax_apv_chart" style="width: 100%; height: 400px;"></div>
-        </div>
-      {% endif %}
-      <div class="col-md-6 m-auto">
-        <table class="table table-bordered">
-          <thead>
-            <tr class="table-info">
-              <th></th>
-              <th>WEA</th>
-              <th>FF-PV</th>
-              <th>APV</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>Max. jährl. GewSt.</td>
-              <td>{{ results.max_tax_3 }} €</td>
-              <td>{{ results.max_tax_1 }} €</td>
-              <td>{{ results.max_tax_2 }} €</td>
-            </tr>
-            <tr>
-              <td>Einnahmen über 25 Jahre</td>
-              <td>{{ results.total_trade_tax_3 }} €</td>
-              <td>{{ results.total_trade_tax_1 }} €</td>
-              <td>{{ results.total_trade_tax_2 }} €</td>
-            </tr>
-          </tbody>
-        </table>
-        <div class="expandable-text bg-light p-4 small text-muted">
-          <p class="mb-0">
-            <b>Allgemeine Annahmen:</b>
-          </p>
-          <ul>
-            <li>Zinssatz in Höhe von 5 %</li>
-            <li>Eigenkapitalanteil von 80 %</li>
-            <li>Tilgungsdauer von 15 Jahren</li>
-          </ul>
-          <span class="collapse">
-            <p class="mb-0">
-              <b>Annahmen WEA:</b>
-            </p>
-            <ul>
-              <li>Angenommene Volllaststunden:</li>
-              <li>Jährliche Leistungsdegradation von 0,6 %</li>
-            </ul>
-            <p class="mb-0">
-              <b>Annahmen FF-PV:</b>
-            </p>
-            <ul>
-              <li>Angenommene Volllaststunden:</li>
-              <li>Jährliche Leistungsdegradation von 0,5 %</li>
-            </ul>
-            <p>
-              Für eine detaillierte Dokumentation aller getroffener Annahmen siehe <a href="#" title="Dokumentation">hier</a>.
-            </p>
-          </span>
-          <a class="expand-btn mt-2 d-block" href="#" role="button">+ Mehr anzeigen</a>
-        </div>
-      </div>
-    </div>
-    <hr />
-    <h2 class="rowHeader">Gesamteinnahmen über 25 Jahre</h2>
-    <div class="row">
-      <div class="col-md-12">
-        <div id="total_income_loader" class="loader"></div>
-        <div id="total_income_chart" style="width: 100%; height: 500px;"></div>
-      </div>
-    </div>
-    <div class="col-md-6 m-auto">
-      <table class="table table-bordered">
-        <thead>
-          <tr class="table-info">
-            <th>WEA</th>
-            <th>FF-PV</th>
-            <th>APV</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>{{ results.sum_wea }} €</td>
-            <td>{{ results.sum_ff_pv }} €</td>
-            <td>{{ results.sum_agri_pv }} €</td>
-          </tr>
-        </tbody>
-      </table>
     </div>
   </div>
 </div>
-</div>
-</div>
+
 {% endblock content_no_sidebar %}
 {% block inline_javascript %}
   <script>

--- a/slapp/kommWertTool/templates/added_value_results.html
+++ b/slapp/kommWertTool/templates/added_value_results.html
@@ -510,7 +510,6 @@
       const addedValueContent = document.querySelectorAll(".av-results .tab-content");
   
       addedValueButtons.forEach((button) => {
-        console.log(button);
         button.addEventListener("click", () => {
           // Remove active class from all buttons and contents
           addedValueButtons.forEach((btn) => btn.classList.remove("active"));
@@ -519,6 +518,15 @@
           // Add active class to clicked button and corresponding content
           button.classList.add("active");
           document.getElementById(button.dataset.tab).classList.add("active");
+
+          // Resize chart correctly
+          if (button.dataset.tab === "revenue") {
+            console.log("test");
+            const totalIncomeChart = echarts.getInstanceByDom(document.getElementById("total_income_chart"));
+            setTimeout(() => {
+              totalIncomeChart.resize();
+            }, 50);
+          }
         });
       });
     });

--- a/slapp/kommWertTool/templates/added_value_results.html
+++ b/slapp/kommWertTool/templates/added_value_results.html
@@ -59,18 +59,18 @@
                     </tbody>
                   </table>
                   <div class="av-results__details">
-                    <p>
-                      <b>Annahmen:</b>
-                    </p>
-                    <ul class="mb-0">
+                    <div class="title">
+                      <h3>Annahmen:</h3>
+                    </div>
+                    <ul class="list">
                       <li>Es findet keine Eigennutzung der erzeugten Strommmenge statt</li>
                       <li>Beteiligung von 0,2 Cent pro kWh</li>
                     </ul>
-                    <span>
+                    <div class="more">
                       <p>
                         Für eine detaillierte Dokumentation aller getroffener Annahmen siehe <a href="#" title="Dokumentation">hier</a>.
                       </p>
-                    </span>
+                    </div>
                   </div>
                 </div>
               </div>
@@ -104,19 +104,19 @@
                       </tbody>
                     </table>
                     <div class="av-results__details">
-                      <p>
-                        <b>Annahmen:</b>
-                      </p>
-                      <ul>
+                      <div class="title">
+                        <h3>Annahmen:</h3>
+                      </div>
+                      <ul class="list">
                         <li>
                           Die bisher geltende Regelung von 10.000,00 pro WEA wird nicht berücksichtigt. Es wird davon ausgegangen, dass alle WEA erst ab 2026 in Betrieb gehen.
                         </li>
                       </ul>
-                      <span>
+                      <div class="more">
                         <p>
                           Für eine detaillierte Dokumentation aller getroffener Annahmen siehe <a href="#" title="Dokumentation">hier</a>.
                         </p>
-                      </span>
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -161,38 +161,36 @@
                     </tbody>
                   </table>
                   <div class="av-results__details">
-                    <p>
-                      <b>Allgemeine Annahmen:</b>
-                    </p>
-                    <ul>
+                    <div class="title">
+                      <h3>Allgemeine Annahmen:</h3>
+                    </div>
+                    <ul class="list">
                       <li>Zugrundeliegende Pachtpreise: WEA = 16.000,00 € pro MW; FF-PV = 3.000,00 € pro ha; APV = 830,00 € pro ha</li>
                     </ul>
-                    <span class="collapse">
-                      <p>
-                        <b>Annahmen ESt.-Berechnung:</b>
-                      </p>
-                      <ul>
+                    <div class="title">
+                      <h3>Annahmen ESt.-Berechnung:</h3>
+                      <ul class="list">
                         <li>
                           Durchschnittliches DE-weites Brutto-Jahreseinkommen von 59.094,00 € <a href="https://www.destatis.de/DE/Themen/Arbeit/Verdienste/Verdienste-Branche-Berufe/Tabellen/bruttojahresverdienst.html"
-            title="Statistisches Bundesamt"
-            target="_blank"><i class="fas fa-link"></i></a>
+                          title="Statistisches Bundesamt"
+                          target="_blank"><i class="fas fa-link"></i></a>
                         </li>
                         <li>ledige Person</li>
                       </ul>
-                      <p class="mb-0">
-                        <b>Annahmen GewSt.-Berechnung:</b>
-                      </p>
-                      <ul>
+                      <div class="title">
+                        <h3>Annahmen GewSt.-Berechnung:</h3>
+                      </div>
+                      <ul class="list">
                         <li>Kein Steuerfreibetrag aufgrund von Unternehmensform</li>
                         <li>
                           Berücksichtigung der Gewerbesteuerumlage laut Gemeindefinanzreformgesetz <a href="https://www.bundesfinanzministerium.de/Content/DE/Standardartikel/Themen/Oeffentliche_Finanzen/Foederale_Finanzbeziehungen/Kommunalfinanzen/Gemeindefinanzreform/entwicklung-gewerbesteuerumlage.pdf"
-            target="_blank"
-            title="Gewerbesteuerumlage"><i class="fas fa-link"></i></a>
+                          target="_blank"
+                          title="Gewerbesteuerumlage"><i class="fas fa-link"></i></a>
                         </li>
                       </ul>
-                      <p>
+                      <div class="more">
                         Für eine detaillierte Dokumentation aller getroffener Annahmen siehe <a href="#" title="Dokumentation">hier</a>.
-                      </p>
+                      </div>
                     </span>
                   </div>
                 </div>
@@ -228,17 +226,17 @@
               </tbody>
             </table>
             <div class="av-results__details">
-              <p>
-                <b>Annahmen:</b>
-              </p>
-              <ul>
+              <div class="title">
+                <h3>Annahmen:</h3>
+              </div>
+              <ul class="list">
                 <li>Abgrenzende Standortfläche pro WEA beträgt 0,4 ha</li>
               </ul>
-              <span>
+              <div class="more">
                 <p>
                   Für eine detaillierte Dokumentation aller getroffener Annahmen siehe <a href="#" title="Dokumentation">hier</a>.
                 </p>
-              </span>
+              </div>
             </div>
           </div>
         {% else %}
@@ -250,79 +248,79 @@
         <div id="revenue" class="tab-content">
           <div class="av-results__section">
             <h2 class="rowHeader">Gewerbesteuereinnahmen durch Anlagengewinne</h2>
-            <div class="av-results__section">
-              {% if results.total_trade_tax_3 != "0,00" %}
-                <div class="col-md-6">
-                  <div id="trade_tax_wind_loader" class="loader"></div>
-                  <div id="trade_tax_wind_chart" style="width: 100%; height: 400px;"></div>
+            {% if results.total_trade_tax_3 != "0,00" %}
+              <div class="col-md-6">
+                <div id="trade_tax_wind_loader" class="loader"></div>
+                <div id="trade_tax_wind_chart" style="width: 100%; height: 400px;"></div>
+              </div>
+            {% endif %}
+            {% if results.total_trade_tax_1 != "0,00" %}
+              <div class="col-md-6">
+                <div id="trade_tax_pv_loader" class="loader"></div>
+                <div id="trade_tax_pv_chart" style="width: 100%; height: 400px;"></div>
+              </div>
+            {% endif %}
+            {% if results.total_trade_tax_2 != "0,00" %}
+              <div class="col-md-6">
+                <div id="trade_tax_apv_loader" class="loader"></div>
+                <div id="trade_tax_apv_chart" style="width: 100%; height: 400px;"></div>
+              </div>
+            {% endif %}
+            <div class="col-md-6 m-auto">
+              <table class="table table-bordered">
+                <thead>
+                  <tr>
+                    <th></th>
+                    <th>WEA</th>
+                    <th>FF-PV</th>
+                    <th>APV</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>Max. jährl. GewSt.</td>
+                    <td>{{ results.max_tax_3 }} €</td>
+                    <td>{{ results.max_tax_1 }} €</td>
+                    <td>{{ results.max_tax_2 }} €</td>
+                  </tr>
+                  <tr>
+                    <td>Einnahmen über 25 Jahre</td>
+                    <td>{{ results.total_trade_tax_3 }} €</td>
+                    <td>{{ results.total_trade_tax_1 }} €</td>
+                    <td>{{ results.total_trade_tax_2 }} €</td>
+                  </tr>
+                </tbody>
+              </table>
+              <div class="av-results__details">
+                <div class="title">
+                  <h3>Allgemeine Annahmen:</h3>
                 </div>
-              {% endif %}
-              {% if results.total_trade_tax_1 != "0,00" %}
-                <div class="col-md-6">
-                  <div id="trade_tax_pv_loader" class="loader"></div>
-                  <div id="trade_tax_pv_chart" style="width: 100%; height: 400px;"></div>
+                <ul class="list">
+                  <li>Zinssatz in Höhe von 5 %</li>
+                  <li>Eigenkapitalanteil von 80 %</li>
+                  <li>Tilgungsdauer von 15 Jahren</li>
+                </ul>
+                <div class="title">
+                  <h3>Annahmen WEA:</h3>
                 </div>
-              {% endif %}
-              {% if results.total_trade_tax_2 != "0,00" %}
-                <div class="col-md-6">
-                  <div id="trade_tax_apv_loader" class="loader"></div>
-                  <div id="trade_tax_apv_chart" style="width: 100%; height: 400px;"></div>
+                <ul class="list">
+                  <li>Angenommene Volllaststunden:</li>
+                  <li>Jährliche Leistungsdegradation von 0,6 %</li>
+                </ul>
+                <div class="title">
+                  <h3>Annahmen FF-PV:</h3>
                 </div>
-              {% endif %}
-              <div class="col-md-6 m-auto">
-                <table class="table table-bordered">
-                  <thead>
-                    <tr>
-                      <th></th>
-                      <th>WEA</th>
-                      <th>FF-PV</th>
-                      <th>APV</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr>
-                      <td>Max. jährl. GewSt.</td>
-                      <td>{{ results.max_tax_3 }} €</td>
-                      <td>{{ results.max_tax_1 }} €</td>
-                      <td>{{ results.max_tax_2 }} €</td>
-                    </tr>
-                    <tr>
-                      <td>Einnahmen über 25 Jahre</td>
-                      <td>{{ results.total_trade_tax_3 }} €</td>
-                      <td>{{ results.total_trade_tax_1 }} €</td>
-                      <td>{{ results.total_trade_tax_2 }} €</td>
-                    </tr>
-                  </tbody>
-                </table>
-                <div class="av-results__details">
-                  <p>
-                    <b>Allgemeine Annahmen:</b>
-                  </p>
-                  <ul>
-                    <li>Zinssatz in Höhe von 5 %</li>
-                    <li>Eigenkapitalanteil von 80 %</li>
-                    <li>Tilgungsdauer von 15 Jahren</li>
-                  </ul>
-                  <p>
-                    <b>Annahmen WEA:</b>
-                  </p>
-                  <ul>
-                    <li>Angenommene Volllaststunden:</li>
-                    <li>Jährliche Leistungsdegradation von 0,6 %</li>
-                  </ul>
-                  <p>
-                    <b>Annahmen FF-PV:</b>
-                  </p>
-                  <ul>
-                    <li>Angenommene Volllaststunden:</li>
-                    <li>Jährliche Leistungsdegradation von 0,5 %</li>
-                  </ul>
-                  <p>
-                    Für eine detaillierte Dokumentation aller getroffener Annahmen siehe <a href="#" title="Dokumentation">hier</a>.
-                  </p>
+                <ul class="list">
+                  <li>Angenommene Volllaststunden:</li>
+                  <li>Jährliche Leistungsdegradation von 0,5 %</li>
+                </ul>
+                <div class="more">
+                  Für eine detaillierte Dokumentation aller getroffener Annahmen siehe <a href="#" title="Dokumentation">hier</a>.
                 </div>
               </div>
             </div>
+          </div>
+          <div class="av-results__section">
             <h2 class="rowHeader">Gesamteinnahmen über 25 Jahre</h2>
             <div class="row">
               <div class="col-md-12">

--- a/slapp/static/scss/layouts/_added_value.scss
+++ b/slapp/static/scss/layouts/_added_value.scss
@@ -136,3 +136,53 @@
     width: auto;
   }
 }
+
+.av-results {
+  &__tabs {
+    display: flex;
+    justify-content: center;
+    gap: 2rem;
+    padding: 0.5rem 0;
+    max-width: 40rem;
+    margin: 0 auto;
+  }
+
+  .tab-button {
+    flex: 1;
+    text-align: center;
+    background: none;
+    border: none;
+    font-size: 1rem;
+    font-weight: 600;
+    color: $font-color-secondary;
+    cursor: pointer;
+    padding: 0.75rem 0;
+    position: relative;
+  }
+
+  .tab-button.active {
+    font-weight: 700;
+    color: $font-color-main;
+  }
+
+  .tab-button.active::after {
+    content: "";
+    position: absolute;
+    bottom: -2px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 60%;
+    height: 4px;
+    background: $font-color-main;
+    border-radius: 2px;
+  }
+
+  .tab-content {
+    display: none;
+    padding: 20px;
+  }
+
+  .tab-content.active {
+    display: block;
+  }
+}

--- a/slapp/static/scss/layouts/_added_value.scss
+++ b/slapp/static/scss/layouts/_added_value.scss
@@ -223,13 +223,17 @@
     border-radius: $border-radius;
   }
 
+  &__text {
+    flex: 1;
+  }
+
   &__table {
     flex: 1;
   }
 
   table {
-    margin-top: 2rem;
     margin-bottom: 2rem;
+    font-size: 0.875rem;
   }
 
   thead tr th {
@@ -247,7 +251,7 @@
     .title h3 {
       font-size: 0.875rem;
       font-weight: 700;
-      color: $font-color-main;
+      color: $font-color-secondary;
       padding-bottom: 0.5rem;
     }
 
@@ -257,12 +261,12 @@
 
     .more {
       font-size: 0.875rem;
+    }
 
-      a {
-        color: $color-link;
-        font-weight: 700;
-        text-decoration: underline;
-      }
+    a {
+      color: $color-link;
+      font-weight: 700;
+      text-decoration: underline;
     }
   }
 }

--- a/slapp/static/scss/layouts/_added_value.scss
+++ b/slapp/static/scss/layouts/_added_value.scss
@@ -212,8 +212,12 @@
   }
 
   &__wrapper {
-    display: flex;
+    display: column;
     gap: 4rem;
+
+    @media only screen and (min-width: 1200px) {
+      display: flex;
+    }
   }
 
   &__chart {
@@ -221,14 +225,29 @@
     background-color: $white;
     padding: 2rem;
     border-radius: $border-radius;
+    margin-bottom: 2rem;
+
+    @media only screen and (min-width: 1200px) {
+      margin-bottom: 0;
+    }
   }
 
   &__text {
     flex: 1;
+    margin-bottom: 2rem;
+
+    @media only screen and (min-width: 1200px) {
+      margin-bottom: 0;
+    }
   }
 
   &__table {
     flex: 1;
+    margin-bottom: 2rem;
+
+    @media only screen and (min-width: 1200px) {
+      margin-bottom: 0;
+    }
   }
 
   table {

--- a/slapp/static/scss/layouts/_added_value.scss
+++ b/slapp/static/scss/layouts/_added_value.scss
@@ -138,6 +138,13 @@
 }
 
 .av-results {
+  background-color: $bg-color-light;
+
+  &__container {
+    @include container;
+    padding: 4rem 0;
+  }
+
   &__tabs {
     display: flex;
     justify-content: center;
@@ -184,5 +191,57 @@
 
   .tab-content.active {
     display: block;
+  }
+
+  &__section {
+    @extend .row;
+    padding-top: 4rem;
+    padding-bottom: 2rem;
+
+    h2 {
+      font-size: 1.5rem;
+      font-weight: 700;
+      text-align: center;
+      padding-bottom: 1.5rem;
+    }
+
+    p {
+      font-size: 0.875rem;;
+      line-height: 1.6;
+    }
+  }
+
+  &__wrapper {
+    display: flex;
+    gap: 4rem;
+  }
+
+  &__chart {
+    flex: 1;
+    background-color: $white;
+    padding: 2rem;
+    border-radius: $border-radius;
+  }
+
+  &__table {
+    flex: 1;
+  }
+
+  table {
+    margin-top: 2rem;
+    margin-bottom: 2rem;
+  }
+
+  thead tr th {
+    background-color: $white;
+  }
+
+  tbody tr td {
+    background-color: transparent;
+  }
+  
+  &__details {
+    font-size: 0.875rem;
+    color: $font-color-secondary;
   }
 }

--- a/slapp/static/scss/layouts/_added_value.scss
+++ b/slapp/static/scss/layouts/_added_value.scss
@@ -243,5 +243,26 @@
   &__details {
     font-size: 0.875rem;
     color: $font-color-secondary;
+
+    .title h3 {
+      font-size: 0.875rem;
+      font-weight: 700;
+      color: $font-color-main;
+      padding-bottom: 0.5rem;
+    }
+
+    .list {
+      font-size: 0.875rem;
+    }
+
+    .more {
+      font-size: 0.875rem;
+
+      a {
+        color: $color-link;
+        font-weight: 700;
+        text-decoration: underline;
+      }
+    }
   }
 }


### PR DESCRIPTION
@nesnoj I've tried to style the results content similar to the [calculator](https://sl-app.apps2.rl-institut.de/added_value/).

- I added a tabs component to make it more digestible. Does it make sense? If we keep it, we should probably improve the category names or content. For example "Einnahmen durch Pachterlöse" is not visible for me, only the alert, but it should probably go to another category?
- Not all charts and content were visible for me, so I hope that I didn't miss anything. For example, as mentioned, "Einnahmen durch Pachterlöse", but also some charts in "Gewerbesteuereinnahmen durch Anlagengewinne". That's why it can make the layouts look a bit inconsistent (not always two columns layout)
- I wanted to keep the layout from "Gesamteinnahmen über 25 Jahre" in two columns, but then half of the chart was not visible, so I kept it in one column

Close #186 